### PR TITLE
restrict test action to PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,6 @@
 name: Test
 
 on:
-  push:
-    branches:
-      - main
-      - master
   pull_request:
     branches:
       - main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: Test
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
     branches:
       - main
       - master


### PR DESCRIPTION
I expect that this will restrict the running of the test action to be in the pr, and not after the PR is merged.