### PR TITLE
pyspark now not an explicit dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools wheel twine
+          pip install pyspark
       - name: Build
         run: |
           python setup.py sdist bdist_wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-      - name: Install Tox and any other packages
-        run: pip install tox pyspark
-      - name: Run Tox
-        # Run tox using the version of Python in `PATH`
-        run: tox -e py
+      - name: Install pytest and any other packages
+        run: |
+          pip install pytest pyspark
+          python setup.py develop
+      - name: Run Tests
+        run: python -m pytest tests/
 
   version_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install Tox and any other packages
-        run: pip install tox
+        run: pip install tox pyspark
       - name: Run Tox
         # Run tox using the version of Python in `PATH`
         run: tox -e py
@@ -40,6 +40,7 @@ jobs:
           python-version: "3.8"
       - name: Extract current version
         run: |
+          pip install pyspark
           python setup.py develop
           python -c"import atc; print(f'::set-output name=VERSION::{atc.__version__}')"
         id: head_checkout

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # atc-dataplatform
 A common set of python libraries for DataBricks
 
+## Important Notes
+
+This package can not be run or tested without access to pyspark.
+However, installing pyspark as part of our installer gave issues when
+other versions of pyspark were needed. Hence we took out the dependency
+from our installer.
+
 ### General Project Info
 [![Github top language](https://img.shields.io/github/languages/top/atc-net/atc-dataplatform)](https://github.com/atc-net/atc-dataplatform)
 [![Github stars](https://img.shields.io/github/stars/atc-net/atc-dataplatform)](https://github.com/atc-net/atc-dataplatform)

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setuptools.setup(
     ],
     python_requires='>=3.8',
     install_requires=[
-        'databricks-connect',
         'pyyaml',
         'sqlparse',
         'more_itertools'

--- a/src/atc/__init__.py
+++ b/src/atc/__init__.py
@@ -2,7 +2,7 @@
 A common set of python libraries for DataBricks.
 See https://github.com/atc-net/atc-dataplatform for details
 """
-__version__ = "0.1.9"
+__version__ = "0.1.10"
 
 from atc import spark
 from atc import sql


### PR DESCRIPTION
pyspark now not an explicit dependency. Installed in the pipelines instead