### PR TITLE
version manipulation no longer depends on installed atc version

### DIFF
--- a/utilities/manipulate_version.py
+++ b/utilities/manipulate_version.py
@@ -3,21 +3,23 @@ Replace whatever version is in atc/__init__.py
 with <major>.<minor>.<git rev-list --count>
 This facilitates continuous release.
 """
-import importlib.resources as res
 import re
 from subprocess import check_output
 
+init_file_path = "src/atc/__init__.py"
+
 
 def main():
-    version = int(check_output(['git', 'rev-list', '--count', 'HEAD']).decode().strip())
-    with res.path("atc","__init__.py") as p:
-        conts = open(p).read()
-        new_conts = re.sub(r'__version__\s+=\s+"(\d+)\.(\d+)\.\w+"',
-                           rf'__version__ = "\1.\2.{version}"',
-                           conts,
-                           count=1)
-        with open(p,"w") as f:
-            f.write(new_conts)
+    version = int(check_output(["git", "rev-list", "--count", "HEAD"]).decode().strip())
+    conts = open(init_file_path).read()
+    new_conts = re.sub(
+        r'__version__\s+=\s+"(\d+)\.(\d+)\.\w+"',
+        rf'__version__ = "\1.\2.{version}"',
+        conts,
+        count=1,
+    )
+    with open(init_file_path, "w") as f:
+        f.write(new_conts)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
the previous version depended on having called `python setup.py develop` which was not the case in the pipeline.