### PR TITLE
standard git hooks can now be installed easily

### DIFF
--- a/docs/utilities/README.md
+++ b/docs/utilities/README.md
@@ -1,0 +1,20 @@
+# Utilities documentation
+
+Utilities in atc-dataplatform:
+
+* [Git Hooks](#git-hooks)
+
+## Git Hooks
+
+A set of standard git hooks are included to provide useful functionality
+
+- *pre-commit* before every commit, all files ending in `.py` will be formatted with the black code formatter
+
+To use the hooks, they can be installed in any repository by executing this command from a path inside the repository:
+
+    atc-dataplatform-git-hooks
+
+To uninstall the hooks, simply run this command
+
+    atc-dataplatform-git-hooks uninstall
+

--- a/setup.py
+++ b/setup.py
@@ -1,60 +1,56 @@
 import setuptools
 import re
 
-with open('README.md', 'r', encoding='utf-8') as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
+
 
 def get_version():
     with open("src/atc/__init__.py") as f:
         return re.search(r'__version__\s+=\s+"(\d+\.\d+\.\w+)"', f.read()).group(1)
 
+
 setuptools.setup(
-    name='atc-dataplatform',
-    author='ATC.Net',
+    name="atc-dataplatform",
+    author="ATC.Net",
     version=get_version(),
-    author_email='atcnet.org@gmail.com',
-    description='A common set of python libraries for DataBricks',
-    keywords='databricks, pyspark',
+    author_email="atcnet.org@gmail.com",
+    description="A common set of python libraries for DataBricks",
+    keywords="databricks, pyspark",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/atc-net/atc-dataplatform',
+    long_description_content_type="text/markdown",
+    url="https://github.com/atc-net/atc-dataplatform",
     license_files=["LICENSE"],
     project_urls={
-        'Documentation': 'https://github.com/atc-net/atc-dataplatform',
-        'Bug Reports':
-        'https://github.com/atc-net/atc-dataplatform/issues',
-        'Source Code': 'https://github.com/atc-net/atc-dataplatform',
+        "Documentation": "https://github.com/atc-net/atc-dataplatform",
+        "Bug Reports": "https://github.com/atc-net/atc-dataplatform/issues",
+        "Source Code": "https://github.com/atc-net/atc-dataplatform",
     },
-    package_dir={'': 'src'},
-    packages=setuptools.find_packages(where='src'),
+    package_dir={"": "src"},
+    packages=setuptools.find_packages(where="src"),
     classifiers=[
         # see https://pypi.org/classifiers/
-        'Development Status :: 2 - Pre-Alpha',
-
-        'Intended Audience :: Developers',
-        'Topic :: Software Development :: Build Tools',
-
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3 :: Only',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
+        "Development Status :: 2 - Pre-Alpha",
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Build Tools",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3 :: Only",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
     ],
-    python_requires='>=3.7',
-    install_requires=[
-        'pyyaml',
-        'sqlparse',
-        'more_itertools'
-    ],
+    python_requires=">=3.7",
+    install_requires=["pyyaml", "sqlparse", "more_itertools"],
     extras_require={
-        'dev': ['check-manifest'],
+        "dev": ["check-manifest"],
         # 'test': ['coverage'],
     },
     entry_points={
-        'console_scripts': [
+        "console_scripts": [
             # see explanation in file:
-            'python3=atc.alias:python3',
+            "python3=atc.alias:python3",
+            "atc-dataplatform-git-hooks=atc.formatting.git_hooks:main",
         ],
     },
 )

--- a/src/atc/__init__.py
+++ b/src/atc/__init__.py
@@ -3,7 +3,7 @@ A common set of python libraries for DataBricks.
 See https://github.com/atc-net/atc-dataplatform for details
 """
 
-__version__ = "0.3.x"
+__version__ = "0.3.0"
 
 from atc import spark
 from atc import sql

--- a/src/atc/formatting/git_hooks.py
+++ b/src/atc/formatting/git_hooks.py
@@ -30,7 +30,7 @@ def pre_commit():
     This pre-commit hook runs the black code formatter on all changed files
     that end in ".py"
     """
-    print("pre-commit hook")
+    print("atc-dataplatform pre-commit hook")
 
     # this command
     # $> git diff --cached --name-status

--- a/src/atc/formatting/git_hooks.py
+++ b/src/atc/formatting/git_hooks.py
@@ -1,0 +1,98 @@
+"""
+This script installs and runs git commit hooks.
+To install the hooks, please run
+
+$> python git_hooks.py
+
+To uninstall the git hooks, run
+
+$> python git_hooks.py uninstall
+
+"""
+import subprocess
+import sys
+from textwrap import dedent
+from pathlib import Path
+import os
+
+
+actions = {}
+
+
+def action(func):
+    global actions
+    actions[func.__name__.replace("_", "-")] = func
+
+
+@action
+def pre_commit():
+    """
+    This pre-commit hook runs the black code formatter on all changed files
+    that end in ".py"
+    """
+    print("pre-commit hook")
+    files_to_check = []
+    for line in (
+        subprocess.run(
+            ["git", "diff", "--cached", "--name-status"], capture_output=True
+        )
+        .stdout.decode()
+        .splitlines()
+    ):
+        print(line)
+        diff, path = tuple(line.strip().split(maxsplit=2))
+        if diff.strip().lower() == "d":
+            continue
+        if not path.endswith(".py"):
+            continue
+        files_to_check.append(path)
+
+    subprocess.run(["black", *files_to_check], check=True)
+    subprocess.run(["git", "add", *files_to_check], check=True)
+
+
+def get_hooks_dir() -> Path:
+    for path in [Path.cwd()] + list(Path().cwd().parents):
+        if (path / ".git").is_dir():
+            break
+    else:
+        raise AssertionError(
+            "Git hooks directory not found. Please run this script form the repo base."
+        )
+
+    return path / ".git" / "hooks"
+
+
+def install() -> None:
+    print("Now installing hooks.")
+
+    hooks_dir = get_hooks_dir()
+
+    for command in actions.keys():
+        with open(hooks_dir / command, "w") as f:
+            print(f"Installing hook for '{command}'")
+            f.write(
+                dedent(
+                    f"""
+                    #!{sys.executable}
+                    from atc.formatting.git_hooks import actions
+                    actions[{repr(command)}]()
+                """
+                ).strip()
+            )
+    print("Done installing hooks.")
+
+
+def uninstall() -> None:
+    print("uninstalling git hooks")
+    hooks_dir = get_hooks_dir()
+    for command in actions.keys():
+        print(f"  uninstalling '{command}'")
+        os.unlink(hooks_dir / command)
+
+
+def main():
+    if "uninstall" in sys.argv:
+        uninstall()
+    else:
+        install()

--- a/src/atc/formatting/git_hooks.py
+++ b/src/atc/formatting/git_hooks.py
@@ -31,6 +31,13 @@ def pre_commit():
     that end in ".py"
     """
     print("pre-commit hook")
+
+    # this command
+    # $> git diff --cached --name-status
+    # results in an output like
+    # M       src/atc/formatting/git_hooks.py
+    # with one line per Modified, Deleted, or New file.
+    # we don't want to reformat deleted files, all others should be formatted.
     files_to_check = []
     for line in (
         subprocess.run(
@@ -39,7 +46,6 @@ def pre_commit():
         .stdout.decode()
         .splitlines()
     ):
-        print(line)
         diff, path = tuple(line.strip().split(maxsplit=2))
         if diff.strip().lower() == "d":
             continue
@@ -47,7 +53,9 @@ def pre_commit():
             continue
         files_to_check.append(path)
 
+    # first reformat all affected python files
     subprocess.run(["black", *files_to_check], check=True)
+    # now add all reformatted files back to be committed
     subprocess.run(["git", "add", *files_to_check], check=True)
 
 


### PR DESCRIPTION

## Git Hooks

A set of standard git hooks are included to provide useful functionality

- *pre-commit* before every commit, all files ending in `.py` will be formatted with the black code formatter

To use the hooks, they can be installed in any repository by executing this command from a path inside the repository:

    atc-dataplatform-git-hooks

To uninstall the hooks, simply run this command

    atc-dataplatform-git-hooks uninstall
