### PR TITLE
Git diff using diff-filter is more robust

### DIFF
--- a/src/atc/formatting/git_hooks.py
+++ b/src/atc/formatting/git_hooks.py
@@ -60,6 +60,10 @@ def pre_commit():
             continue
         files_to_check.append(path)
 
+    if not files_to_check:
+        print("  Nothing to do.")
+        return
+
     # first reformat all affected python files
     subprocess.run(["black", *files_to_check], check=True)
     # now add all reformatted files back to be committed
@@ -88,11 +92,15 @@ def install() -> None:
             print(f"Installing hook for '{command}'")
             f.write(
                 dedent(
-                    f"""
+                    rf"""
                     #!{sys.executable}
-                    from atc.formatting.git_hooks import actions
-                    actions[{repr(command)}]()
-                """
+                    try:
+                        from atc.formatting.git_hooks import actions
+                        actions[{repr(command)}]()
+                    except ModuleNotFoundError as e:
+                        import sys
+                        print(e,'\nsearch path was:\n-','\n- '.join(sys.path))
+                    """
                 ).strip()
             )
     print("Done installing hooks.")

--- a/src/atc/formatting/git_hooks.py
+++ b/src/atc/formatting/git_hooks.py
@@ -33,22 +33,29 @@ def pre_commit():
     print("atc-dataplatform pre-commit hook")
 
     # this command
-    # $> git diff --cached --name-status
+    # $> git diff --cached --name-only --diff-filter=d
     # results in an output like
-    # M       src/atc/formatting/git_hooks.py
-    # with one line per Modified, Deleted, or New file.
+    # src/atc/formatting/git_hooks.py
+    # with one line per Modified or New file, deleted files are excluded
     # we don't want to reformat deleted files, all others should be formatted.
     files_to_check = []
     for line in (
         subprocess.run(
-            ["git", "diff", "--cached", "--name-status"], capture_output=True
+            [
+                "git",
+                "diff",
+                "--cached",
+                # only show the names, one name per line
+                "--name-only",
+                # diff filter lowercase d means exclude deleted files
+                "--diff-filter=d",
+            ],
+            capture_output=True,
         )
         .stdout.decode()
         .splitlines()
     ):
-        diff, path = tuple(line.strip().split(maxsplit=2))
-        if diff.strip().lower() == "d":
-            continue
+        path = line.strip()
         if not path.endswith(".py"):
             continue
         files_to_check.append(path)


### PR DESCRIPTION
I saw a git diff --name-status that looked like this

R096    src/my/file.py   src/my/file.py

I never found out what that even means, but it broke the previous filter