### PR TITLE
all Etl objects can now exchange arguments

### DIFF
--- a/src/atc/etl/orchestrator.py
+++ b/src/atc/etl/orchestrator.py
@@ -1,23 +1,33 @@
-from typing import List
+from typing import List, Dict, Any
 
 from pyspark.sql import DataFrame
 
 from .types import EtlBase, dataset_group
 
 
-class Orchestrator:
+class Orchestrator(EtlBase):
     """
     It is up to the user of this library that extractors,
     transformers and loaders live up to their names and are not
     used in a wrong order.
     """
 
-    def __init__(self):
+    def __init__(self, args: Dict[str, Any] = None):
+        super().__init__()
         self.steps: List[EtlBase] = []
+        if args is None:
+            args = {}
+        self.args = args
 
     def step(self, etl: EtlBase) -> "Orchestrator":
         self.steps.append(etl)
+        etl.set_orchestrator_args(self.args)
         return self
+
+    def set_orchestrator_args(self, args: Dict[str, Any]) -> None:
+        self.args = args
+        for etl in self.steps:
+            etl.set_orchestrator_args(args)
 
     # these are just synonyms for readability
     extract_from = step
@@ -25,10 +35,13 @@ class Orchestrator:
     load_into = step
 
     def execute(self) -> DataFrame:
-        datasets: dataset_group = {}
-        for step in self.steps:
-            datasets = step.etl(datasets)
+        datasets = self.etl({})
 
         if len(datasets) == 1:
             return next(iter(datasets.values()))
         raise AssertionError("Multiple datasets in play at the end of orchestration.")
+
+    def etl(self, datasets: dataset_group) -> dataset_group:
+        for step in self.steps:
+            datasets = step.etl(datasets)
+        return datasets

--- a/src/atc/etl/types.py
+++ b/src/atc/etl/types.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Dict
+from typing import Dict, Any, Optional
 
 from pyspark.sql import DataFrame
 
@@ -7,6 +7,21 @@ dataset_group = Dict[str, DataFrame]
 
 
 class EtlBase:
+    orchestrator_args: Optional[Dict[str, Any]] = None
+
     @abstractmethod
     def etl(self, inputs: dataset_group) -> dataset_group:
         pass
+
+    def set_orchestrator_args(self, args: Dict[str, Any]) -> None:
+        self.orchestrator_args = args
+
+    def get_arg(self, key: str) -> Any:
+        if self.orchestrator_args is None:
+            raise KeyError(f"Orchestrator args not set, unable to get {key}")
+        return self.orchestrator_args[key]
+
+    def set_arg(self, key: str, value: Any) -> None:
+        if self.orchestrator_args is None:
+            raise KeyError(f"Orchestrator args not set, unable to set {key}")
+        self.orchestrator_args[key] = value


### PR DESCRIPTION
- all Etl objects can now exchange arguments
- the orchestrator is itself an Etl object, meaning orchestrators can be steps in higher orchestrators
- ToDo: Tests and documentation
- Closes #58 