### PR TITLE
composit orchestration

### DIFF
--- a/docs/etl/README.md
+++ b/docs/etl/README.md
@@ -528,3 +528,98 @@ etl = (
 etl.execute()
 
 ```
+
+### Example-7
+
+This example illustrates the use of an orchestrator as just another ETL step.
+The principle is called composit orchestration:
+```
+import pyspark.sql.functions as F
+import pyspark.sql.types as T
+from pyspark.sql import DataFrame
+from pyspark.sql.types import IntegerType
+
+from atc.etl import Extractor, Transformer, Loader, Orchestrator, dataset_group
+from atc.spark import Spark
+
+
+class AmericanGuitarExtractor(Extractor):
+    def read(self) -> DataFrame:
+        return Spark.get().createDataFrame(
+            Spark.get().sparkContext.parallelize(
+                [
+                    ("1", "Fender", "Telecaster", "1950"),
+                    ("2", "Gibson", "Les Paul", "1959"),
+                ]
+            ),
+            T.StructType(
+                [
+                    T.StructField("id", T.StringType()),
+                    T.StructField("brand", T.StringType()),
+                    T.StructField("model", T.StringType()),
+                    T.StructField("year", T.StringType()),
+                ]
+            ),
+        )
+
+
+class JapaneseGuitarExtractor(Extractor):
+    def read(self) -> DataFrame:
+        return Spark.get().createDataFrame(
+            Spark.get().sparkContext.parallelize(
+                [
+                    ("3", "Ibanez", "RG", "1987"),
+                    ("4", "Takamine", "Pro Series", "1959"),
+                ]
+            ),
+            T.StructType(
+                [
+                    T.StructField("id", T.StringType()),
+                    T.StructField("brand", T.StringType()),
+                    T.StructField("model", T.StringType()),
+                    T.StructField("year", T.StringType()),
+                ]
+            ),
+        )
+
+
+class CountryOfOriginTransformer(Transformer):
+    def process_many(self, dataset: dataset_group) -> DataFrame:
+        usa_df = dataset["AmericanGuitarExtractor"].withColumn("country", F.lit("USA"))
+        jap_df = dataset["JapaneseGuitarExtractor"].withColumn("country", F.lit("Japan"))
+        return usa_df.union(jap_df)
+
+
+class OrchestratorLoader(Loader):
+    def __init__(self, orchestrator: Orchestrator):
+        super().__init__()
+        self.orchestrator = orchestrator
+
+    def save_many(self, datasets: dataset_group) -> None:
+        self.orchestrator.execute(datasets)
+
+
+class NoopLoader(Loader):
+    def save(self, df: DataFrame) -> None:
+        df.write.format("noop").mode("overwrite").save()
+        df.printSchema()
+        df.show()
+
+
+print("ETL Orchestrator using composit innter orchestrator")
+etl_inner = (
+    Orchestrator()
+    .transform_with(CountryOfOriginTransformer())
+    .load_into(NoopLoader())
+)
+
+etl_outer = (
+    Orchestrator()
+    .extract_from(AmericanGuitarExtractor())
+    .extract_from(JapaneseGuitarExtractor())
+    .load_into(OrchestratorLoader(etl_inner))
+)
+
+etl_outer.execute()
+
+```

--- a/docs/etl/README.md
+++ b/docs/etl/README.md
@@ -36,6 +36,24 @@ from atc.etl import Extractor, Transformer, Loader, Orchestrator
     .execute())
 ```
 
+### Principles
+
+All ETL classes, **Orchestrator**, **Extractor**, **Transformer** and **Loader** are ETL objects.
+This means that they have a method `etl(self, inputs: dataset_group) -> dataset_group`
+(where `dataset_group = Dict[str, DataFrame]`) that transforms a set of import to a set of 
+outputs. The special properties of each type are
+ - **Extractor** always adds its result to the total set,
+ - **Transformer** consumes all inputs and adds a single result dataframe,
+ - **Loader** acts as a sink, while passing its input on to the next sink,
+
+The special case of the  **Orchestrator** is that it takes all its steps and executes them
+in sequence on its inputs. Running in the default `execute()` method, the inputs are empty,
+but an orchestrator can also be added as part of another orchestrator with the `step` method.
+
+For the most general case of a many to many transformation, implement your step by inheriting
+from the `EtlBase` class.
+
+
 ## Usage examples:
 
 Here are some example usages and implementations of the ETL class provided

--- a/docs/etl/README.template.md
+++ b/docs/etl/README.template.md
@@ -164,3 +164,11 @@ It is important that the first transformer is a `MultiInputTransformer` when hav
 ```
 {multi_multi_example}
 ```
+
+### Example-7
+
+This example illustrates the use of an orchestrator as just another ETL step.
+The principle is called composit orchestration:
+```
+{composit_orchestration_example}
+```

--- a/docs/etl/README.template.md
+++ b/docs/etl/README.template.md
@@ -36,6 +36,24 @@ from atc.etl import Extractor, Transformer, Loader, Orchestrator
     .execute())
 ```
 
+### Principles
+
+All ETL classes, **Orchestrator**, **Extractor**, **Transformer** and **Loader** are ETL objects.
+This means that they have a method `etl(self, inputs: dataset_group) -> dataset_group`
+(where `dataset_group = Dict[str, DataFrame]`) that transforms a set of import to a set of 
+outputs. The special properties of each type are
+ - **Extractor** always adds its result to the total set,
+ - **Transformer** consumes all inputs and adds a single result dataframe,
+ - **Loader** acts as a sink, while passing its input on to the next sink,
+
+The special case of the  **Orchestrator** is that it takes all its steps and executes them
+in sequence on its inputs. Running in the default `execute()` method, the inputs are empty,
+but an orchestrator can also be added as part of another orchestrator with the `step` method.
+
+For the most general case of a many to many transformation, implement your step by inheriting
+from the `EtlBase` class.
+
+
 ## Usage examples:
 
 Here are some example usages and implementations of the ETL class provided

--- a/examples/etl/composit_orchestration_example.py
+++ b/examples/etl/composit_orchestration_example.py
@@ -1,0 +1,87 @@
+import pyspark.sql.functions as F
+import pyspark.sql.types as T
+from pyspark.sql import DataFrame
+from pyspark.sql.types import IntegerType
+
+from atc.etl import Extractor, Transformer, Loader, Orchestrator, dataset_group
+from atc.spark import Spark
+
+
+class AmericanGuitarExtractor(Extractor):
+    def read(self) -> DataFrame:
+        return Spark.get().createDataFrame(
+            Spark.get().sparkContext.parallelize(
+                [
+                    ("1", "Fender", "Telecaster", "1950"),
+                    ("2", "Gibson", "Les Paul", "1959"),
+                ]
+            ),
+            T.StructType(
+                [
+                    T.StructField("id", T.StringType()),
+                    T.StructField("brand", T.StringType()),
+                    T.StructField("model", T.StringType()),
+                    T.StructField("year", T.StringType()),
+                ]
+            ),
+        )
+
+
+class JapaneseGuitarExtractor(Extractor):
+    def read(self) -> DataFrame:
+        return Spark.get().createDataFrame(
+            Spark.get().sparkContext.parallelize(
+                [
+                    ("3", "Ibanez", "RG", "1987"),
+                    ("4", "Takamine", "Pro Series", "1959"),
+                ]
+            ),
+            T.StructType(
+                [
+                    T.StructField("id", T.StringType()),
+                    T.StructField("brand", T.StringType()),
+                    T.StructField("model", T.StringType()),
+                    T.StructField("year", T.StringType()),
+                ]
+            ),
+        )
+
+
+class CountryOfOriginTransformer(Transformer):
+    def process_many(self, dataset: dataset_group) -> DataFrame:
+        usa_df = dataset["AmericanGuitarExtractor"].withColumn("country", F.lit("USA"))
+        jap_df = dataset["JapaneseGuitarExtractor"].withColumn("country", F.lit("Japan"))
+        return usa_df.union(jap_df)
+
+
+class OrchestratorLoader(Loader):
+    def __init__(self, orchestrator: Orchestrator):
+        super().__init__()
+        self.orchestrator = orchestrator
+
+    def save_many(self, datasets: dataset_group) -> None:
+        self.orchestrator.execute(datasets)
+
+
+class NoopLoader(Loader):
+    def save(self, df: DataFrame) -> None:
+        df.write.format("noop").mode("overwrite").save()
+        df.printSchema()
+        df.show()
+
+
+print("ETL Orchestrator using composit innter orchestrator")
+etl_inner = (
+    Orchestrator()
+    .transform_with(CountryOfOriginTransformer())
+    .load_into(NoopLoader())
+)
+
+etl_outer = (
+    Orchestrator()
+    .extract_from(AmericanGuitarExtractor())
+    .extract_from(JapaneseGuitarExtractor())
+    .load_into(OrchestratorLoader(etl_inner))
+)
+
+etl_outer.execute()

--- a/src/atc/etl/__init__.py
+++ b/src/atc/etl/__init__.py
@@ -2,10 +2,12 @@ from .loader import Loader
 from .extractor import Extractor
 from .transformer import Transformer
 from .orchestrator import Orchestrator
+from .types import EtlBase
 
 __all__ = [
     "Loader",
     "Extractor",
     "Transformer",
     "Orchestrator",
+    "EtlBase",
 ]

--- a/src/atc/etl/__init__.py
+++ b/src/atc/etl/__init__.py
@@ -2,7 +2,7 @@ from .loader import Loader
 from .extractor import Extractor
 from .transformer import Transformer
 from .orchestrator import Orchestrator
-from .types import EtlBase
+from .types import EtlBase, dataset_group
 
 __all__ = [
     "Loader",
@@ -10,4 +10,5 @@ __all__ = [
     "Transformer",
     "Orchestrator",
     "EtlBase",
+    "dataset_group",
 ]

--- a/src/atc/etl/extractor.py
+++ b/src/atc/etl/extractor.py
@@ -15,6 +15,7 @@ class Extractor(EtlBase):
     """
 
     def __init__(self, dataset_key: str = None):
+        super().__init__()
         if dataset_key is None:
             dataset_key = type(self).__name__
         self.dataset_key = dataset_key

--- a/src/atc/etl/loader.py
+++ b/src/atc/etl/loader.py
@@ -14,6 +14,9 @@ class Loader(EtlBase):
     and does not consume or change it.
     """
 
+    def __init__(self):
+        super().__init__()
+
     def etl(self, inputs: dataset_group) -> dataset_group:
         if len(inputs) == 1:
             df = next(iter(inputs.values()))

--- a/src/atc/etl/orchestrator.py
+++ b/src/atc/etl/orchestrator.py
@@ -26,9 +26,10 @@ class Orchestrator(EtlBase):
     load_into = step
 
     def etl(self, inputs: dataset_group = None) -> dataset_group:
+        inputs = inputs or {}
 
         # make a shallow copy of the inputs for waring after the first step
-        datasets = inputs.copy() if inputs else {}
+        datasets = inputs.copy()
         if not self.steps:
             raise NotImplementedError("The orchestrator has no steps.")
 

--- a/src/atc/etl/orchestrator.py
+++ b/src/atc/etl/orchestrator.py
@@ -1,6 +1,5 @@
+import warnings
 from typing import List
-
-from pyspark.sql import DataFrame
 
 from .types import EtlBase, dataset_group
 
@@ -12,9 +11,10 @@ class Orchestrator(EtlBase):
     used in a wrong order.
     """
 
-    def __init__(self):
+    def __init__(self, suppress_composition_warning=False):
         super().__init__()
         self.steps: List[EtlBase] = []
+        self.suppress_composition_warning = suppress_composition_warning
 
     def step(self, etl: EtlBase) -> "Orchestrator":
         self.steps.append(etl)
@@ -47,9 +47,10 @@ class Orchestrator(EtlBase):
                 and
                 # and has not changed their values
                 all(id(inputs[k]) == id(datasets[k]) for k in inputs.keys())
+                and not self.suppress_composition_warning
             ):
-                print(
-                    "WARNING: You used inputs to the orchestrator, "
+                warnings.warn(
+                    "You used inputs to the orchestrator, "
                     "and the first step did not make use of them. "
                     "Expect problems in your etl pipeline. To avoid this, "
                     "write extractors that clean up in self.previous_extractions"

--- a/src/atc/etl/transformer.py
+++ b/src/atc/etl/transformer.py
@@ -16,6 +16,7 @@ class Transformer(EtlBase):
     """
 
     def __init__(self, dataset_key: str = None):
+        super().__init__()
         if dataset_key is None:
             dataset_key = type(self).__name__
         self.dataset_key = dataset_key

--- a/src/atc/etl/types.py
+++ b/src/atc/etl/types.py
@@ -7,6 +7,9 @@ dataset_group = Dict[str, DataFrame]
 
 
 class EtlBase:
+    def __init__(self):
+        super().__init__()
+
     @abstractmethod
     def etl(self, inputs: dataset_group) -> dataset_group:
         raise NotImplementedError()

--- a/src/atc/transformers/fuzzy_select.py
+++ b/src/atc/transformers/fuzzy_select.py
@@ -30,7 +30,7 @@ class FuzzySelectTransformer(Transformer):
     """
 
     def __init__(self, columns: Iterable[str], match_cutoff=0.6):
-        super(FuzzySelectTransformer, self).__init__()
+        super().__init__()
         self.columns = list(columns)
         self.match_cutoff = match_cutoff
 

--- a/src/atc/utils/MockExtractor.py
+++ b/src/atc/utils/MockExtractor.py
@@ -7,8 +7,8 @@ from atc.etl import Extractor
 
 class MockExtractor(Extractor, MagicMock):
     def __init__(self, *args, dataset_key: str = None, df: DataFrame = None, **kwargs):
-        super(Extractor, self).__init__(dataset_key=dataset_key)
-        super(MagicMock, self).__init__(*args, **kwargs)
+        Extractor.__init__(self, dataset_key=dataset_key)
+        MagicMock.__init__(self, *args, **kwargs)
         self.df = df
 
     def read(self) -> DataFrame:

--- a/src/atc/utils/MockLoader.py
+++ b/src/atc/utils/MockLoader.py
@@ -9,7 +9,7 @@ from atc.etl.types import dataset_group
 
 class MockLoader(Loader, MagicMock):
     def __init__(self, *args, **kwargs):
-        super(MagicMock, self).__init__(*args, **kwargs)
+        MagicMock.__init__(self, *args, **kwargs)
         self.saved: Dict[str, DataFrame] = {}
 
     def save(self, df: DataFrame) -> None:

--- a/tests/etl/test_orchestrator_etl_warning.py
+++ b/tests/etl/test_orchestrator_etl_warning.py
@@ -1,0 +1,67 @@
+import contextlib
+import io
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+from pyspark.sql import DataFrame
+
+from atc.etl import Extractor, Orchestrator
+
+
+class OrchestratorEtlTests(unittest.TestCase):
+    def test_no_special_case(self):
+        class MyEx(Extractor):
+            def read(self) -> DataFrame:
+                return "hi"
+
+        class MyO(Orchestrator):
+            def __init__(self):
+                super().__init__()
+                self.extract_from(MyEx())
+
+        with io.StringIO() as buf:
+            # run the tests
+            with contextlib.redirect_stdout(buf):
+                _ = MyO().execute()
+            self.assertEqual("", buf.getvalue())
+
+    def test_misuse_warning(self):
+        class MyEx(Extractor):
+            def read(self) -> DataFrame:
+                return "hi"
+
+        class MyO(Orchestrator):
+            def __init__(self):
+                super().__init__()
+                self.extract_from(MyEx())
+
+        with io.StringIO() as buf:
+            # run the tests
+            with contextlib.redirect_stdout(buf):
+                _ = MyO().execute({"input": "foobar"})
+            self.assertRegex(buf.getvalue(), "WARNING: You used.*")
+
+    def test_correct_use_no_warning(self):
+        class MyEx(Extractor):
+            def read(self) -> DataFrame:
+                if len(self.previous_extractions):
+                    return self.previous_extractions.popitem()[1]
+                return "hi"
+
+        class MyO(Orchestrator):
+            def __init__(self):
+                super().__init__()
+                self.extract_from(MyEx())
+
+        with io.StringIO() as buf:
+            # run the tests
+            with contextlib.redirect_stdout(buf):
+                _ = MyO().execute({"input": "foobar"})
+            #     No warning. extractor handled inputs.
+            self.assertEqual("", buf.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/etl/test_orchestrator_etl_warning.py
+++ b/tests/etl/test_orchestrator_etl_warning.py
@@ -43,6 +43,23 @@ class OrchestratorEtlTests(unittest.TestCase):
                 _ = MyO().execute({"input": "foobar"})
             self.assertRegex(buf.getvalue(), "WARNING: You used.*")
 
+    def test_misuse_warning_suppressed(self):
+        class MyEx(Extractor):
+            def read(self) -> DataFrame:
+                return "hi"
+
+        class MyO(Orchestrator):
+            def __init__(self):
+                super().__init__(suppress_composition_warning=True)
+                self.extract_from(MyEx())
+
+        with io.StringIO() as buf:
+            # run the tests
+            with contextlib.redirect_stdout(buf):
+                _ = MyO().execute({"input": "foobar"})
+            #     No warning. Suppressed.
+            self.assertEqual("", buf.getvalue())
+
     def test_correct_use_no_warning(self):
         class MyEx(Extractor):
             def read(self) -> DataFrame:


### PR DESCRIPTION
### Principles

All ETL classes, **Orchestrator**, **Extractor**, **Transformer** and **Loader** are ETL objects.
This means that they have a method `etl(self, inputs: dataset_group) -> dataset_group`
(where `dataset_group = Dict[str, DataFrame]`) that transforms a set of import to a set of 
outputs. The special properties of each type are
 - **Extractor** always adds its result to the total set,
 - **Transformer** consumes all inputs and adds a single result dataframe,
 - **Loader** acts as a sink, while passing its input on to the next sink,

The special case of the  **Orchestrator** is that it takes all its steps and executes them
in sequence on its inputs. Running in the default `execute()` method, the inputs are empty,
but an orchestrator can also be added as part of another orchestrator with the `step` method.

For the most general case of a many to many transformation, implement your step by inheriting
from the `EtlBase` class.
