### PR TITLE
consuming loader

### DIFF
--- a/docs/etl/README.md
+++ b/docs/etl/README.md
@@ -510,3 +510,139 @@ result.printSchema()
 result.show()
 
 ```
+
+### Example-7
+
+In some cases a single destination dataset is not sufficient, as seen in this example.
+Here we need to use the full power of the EtlBase class to return multiple datasets that
+are then loaded by separate loaders.
+
+Note that setting a key in the loader constructor allows it to pick out only one of the
+inputs to save.
+
+```
+import pyspark.sql.types as t
+from pyspark.sql import DataFrame
+
+from atc.etl import Extractor, Loader, Orchestrator, EtlBase
+from atc.etl.types import dataset_group
+from atc.spark import Spark
+
+
+class OrdersExtractor(Extractor):
+    def __init__(self):
+        super().__init__(dataset_key="orders")
+
+    def read(self) -> DataFrame:
+        spark = Spark.get()
+        return spark.createDataFrame(
+            Spark.get().sparkContext.parallelize(
+                [
+                    (1, "Guitar", 50),
+                    (2, "Telescope", 200),
+                    (3, "Tablet", 100),
+                ]
+            ),
+            t._parse_datatype_string(
+                """
+                id INTEGER,
+                product STRING,
+                price INTEGER
+            """
+            ),
+        )
+
+
+class PaymentsExtractor(Extractor):
+    def __init__(self):
+        super().__init__(dataset_key="payments")
+
+    def read(self) -> DataFrame:
+        spark = Spark.get()
+        return spark.createDataFrame(
+            Spark.get().sparkContext.parallelize(
+                [
+                    (45, 1, 50),
+                    (46, 2, 200),
+                    (47, 3, 150),
+                ]
+            ),
+            t._parse_datatype_string(
+                """
+                id INTEGER,
+                order_id INTEGER,
+                charged_amount INTEGER
+            """
+            ),
+        )
+
+
+class ReconcilingTransformer(EtlBase):
+    def etl(self, inputs: dataset_group) -> dataset_group:
+        orders = inputs["orders"]
+        payments = inputs["payments"]
+
+        df = orders.join(payments, orders.id == payments.order_id, "left").select(
+            orders.id.alias("order_id"),
+            payments.id.alias("payment_id"),
+            orders.product,
+            orders.price,
+            payments.charged_amount,
+        )
+
+        dispatch = df.filter(df.price == df.charged_amount)
+        service_follow_up = df.filter(~(df.price == df.charged_amount))
+
+        return {"dispatch": dispatch, "service_follow_up": service_follow_up}
+
+
+class DispatchLoader(Loader):
+    def __init__(self):
+        super().__init__("dispatch")
+
+    def save(self, df: DataFrame) -> None:
+        assert df.count() == 2
+        print("Orders ready to dispatch:")
+        df.show()
+
+
+class CustomerServiceLoader(Loader):
+    def __init__(self):
+        super().__init__("service_follow_up")
+
+    def save(self, df: DataFrame) -> None:
+        assert df.count() == 1
+        print("Orders that need follow-up:")
+        df.show()
+
+
+print("ETL Orchestrator using multiple different loaders")
+etl = (
+    Orchestrator()
+    .extract_from(OrdersExtractor())
+    .extract_from(PaymentsExtractor())
+    .transform_with(ReconcilingTransformer())
+    .load_into(DispatchLoader())
+    .load_into(CustomerServiceLoader())
+)
+result = etl.execute()
+
+```
+
+Result:
+```
+Orders ready to dispatch:
++--------+----------+---------+-----+--------------+
+|order_id|payment_id|  product|price|charged_amount|
++--------+----------+---------+-----+--------------+
+|       2|        46|Telescope|  200|           200|
+|       1|        45|   Guitar|   50|            50|
++--------+----------+---------+-----+--------------+
+
+Orders that need follow-up:
++--------+----------+-------+-----+--------------+
+|order_id|payment_id|product|price|charged_amount|
++--------+----------+-------+-----+--------------+
+|       3|        47| Tablet|  100|           150|
++--------+----------+-------+-----+--------------+
+```

--- a/docs/etl/README.template.md
+++ b/docs/etl/README.template.md
@@ -146,3 +146,34 @@ It is important that the first transformer is a `MultiInputTransformer` when hav
 ```
 {multi_multi_example}
 ```
+
+### Example-7
+
+In some cases a single destination dataset is not sufficient, as seen in this example.
+Here we need to use the full power of the EtlBase class to return multiple datasets that
+are then loaded by separate loaders.
+
+Note that setting a key in the loader constructor allows it to pick out only one of the
+inputs to save.
+
+```
+{many_to_many_example}
+```
+
+Result:
+```
+Orders ready to dispatch:
++--------+----------+---------+-----+--------------+
+|order_id|payment_id|  product|price|charged_amount|
++--------+----------+---------+-----+--------------+
+|       2|        46|Telescope|  200|           200|
+|       1|        45|   Guitar|   50|            50|
++--------+----------+---------+-----+--------------+
+
+Orders that need follow-up:
++--------+----------+-------+-----+--------------+
+|order_id|payment_id|product|price|charged_amount|
++--------+----------+-------+-----+--------------+
+|       3|        47| Tablet|  100|           150|
++--------+----------+-------+-----+--------------+
+```

--- a/examples/etl/many_to_many_example.py
+++ b/examples/etl/many_to_many_example.py
@@ -1,0 +1,105 @@
+import pyspark.sql.types as t
+from pyspark.sql import DataFrame
+
+from atc.etl import Extractor, Loader, Orchestrator, EtlBase
+from atc.etl.types import dataset_group
+from atc.spark import Spark
+
+
+class OrdersExtractor(Extractor):
+    def __init__(self):
+        super().__init__(dataset_key="orders")
+
+    def read(self) -> DataFrame:
+        spark = Spark.get()
+        return spark.createDataFrame(
+            Spark.get().sparkContext.parallelize(
+                [
+                    (1, "Guitar", 50),
+                    (2, "Telescope", 200),
+                    (3, "Tablet", 100),
+                ]
+            ),
+            t._parse_datatype_string(
+                """
+                id INTEGER,
+                product STRING,
+                price INTEGER
+            """
+            ),
+        )
+
+
+class PaymentsExtractor(Extractor):
+    def __init__(self):
+        super().__init__(dataset_key="payments")
+
+    def read(self) -> DataFrame:
+        spark = Spark.get()
+        return spark.createDataFrame(
+            Spark.get().sparkContext.parallelize(
+                [
+                    (45, 1, 50),
+                    (46, 2, 200),
+                    (47, 3, 150),
+                ]
+            ),
+            t._parse_datatype_string(
+                """
+                id INTEGER,
+                order_id INTEGER,
+                charged_amount INTEGER
+            """
+            ),
+        )
+
+
+class ReconcilingTransformer(EtlBase):
+    def etl(self, inputs: dataset_group) -> dataset_group:
+        orders = inputs["orders"]
+        payments = inputs["payments"]
+
+        df = orders.join(payments, orders.id == payments.order_id, "left").select(
+            orders.id.alias("order_id"),
+            payments.id.alias("payment_id"),
+            orders.product,
+            orders.price,
+            payments.charged_amount,
+        )
+
+        dispatch = df.filter(df.price == df.charged_amount)
+        service_follow_up = df.filter(~(df.price == df.charged_amount))
+
+        return {"dispatch": dispatch, "service_follow_up": service_follow_up}
+
+
+class DispatchLoader(Loader):
+    def __init__(self):
+        super().__init__("dispatch")
+
+    def save(self, df: DataFrame) -> None:
+        assert df.count() == 2
+        print("Orders ready to dispatch:")
+        df.show()
+
+
+class CustomerServiceLoader(Loader):
+    def __init__(self):
+        super().__init__("service_follow_up")
+
+    def save(self, df: DataFrame) -> None:
+        assert df.count() == 1
+        print("Orders that need follow-up:")
+        df.show()
+
+
+print("ETL Orchestrator using multiple different loaders")
+etl = (
+    Orchestrator()
+    .extract_from(OrdersExtractor())
+    .extract_from(PaymentsExtractor())
+    .transform_with(ReconcilingTransformer())
+    .load_into(DispatchLoader())
+    .load_into(CustomerServiceLoader())
+)
+result = etl.execute()

--- a/src/atc/etl/__init__.py
+++ b/src/atc/etl/__init__.py
@@ -2,10 +2,6 @@ from .loader import Loader
 from .extractor import Extractor
 from .transformer import Transformer
 from .orchestrator import Orchestrator
+from .etl import EtlBase
 
-__all__ = [
-    "Loader",
-    "Extractor",
-    "Transformer",
-    "Orchestrator",
-]
+__all__ = ["Loader", "Extractor", "Transformer", "Orchestrator", "EtlBase"]

--- a/src/atc/etl/etl.py
+++ b/src/atc/etl/etl.py
@@ -1,0 +1,9 @@
+from abc import abstractmethod
+
+from atc.etl.types import dataset_group
+
+
+class EtlBase:
+    @abstractmethod
+    def etl(self, inputs: dataset_group) -> dataset_group:
+        raise NotImplementedError()

--- a/src/atc/etl/extractor.py
+++ b/src/atc/etl/extractor.py
@@ -2,7 +2,8 @@ from abc import abstractmethod
 
 from pyspark.sql import DataFrame
 
-from .types import dataset_group, EtlBase
+from .types import dataset_group
+from .etl import EtlBase
 
 
 class Extractor(EtlBase):
@@ -28,4 +29,4 @@ class Extractor(EtlBase):
 
     @abstractmethod
     def read(self) -> DataFrame:
-        pass
+        raise NotImplementedError()

--- a/src/atc/etl/loader.py
+++ b/src/atc/etl/loader.py
@@ -2,7 +2,8 @@ from abc import abstractmethod
 
 from pyspark.sql import DataFrame
 
-from .types import dataset_group, EtlBase
+from .types import dataset_group
+from .etl import EtlBase
 
 
 class Loader(EtlBase):
@@ -10,22 +11,38 @@ class Loader(EtlBase):
     A loader is a data sink, which is indicated by the fact that
     the save method has no return.
 
-    In regards to the etl step, a loader USES the input dataset(s)
+    In regards to the etl step, a loader can be used in two ways.
+    If no dataset keys are given, it USES the input dataset(s)
     and does not consume or change it.
+    If one or several dataset keys are given, those are CONSUMED
+    and passed on to the save or save_many methods, while the rest
+    are passed on
     """
 
+    def __init__(self, *dataset_keys: str):
+        super().__init__()
+        self.dataset_keys = dataset_keys
+
     def etl(self, inputs: dataset_group) -> dataset_group:
-        if len(inputs) == 1:
-            df = next(iter(inputs.values()))
-            self.save(df)
-            return inputs
-        self.save_many(inputs)
+        if not self.dataset_keys:
+            if len(inputs) == 1:
+                df = next(iter(inputs.values()))
+                self.save(df)
+            else:
+                self.save_many(inputs)
+        else:
+            if len(self.dataset_keys) == 1:
+                self.save(inputs.pop(self.dataset_keys[0]))
+            else:
+                self.save_many({key: inputs[key] for key in self.dataset_keys})
+                for key in self.dataset_keys:
+                    del inputs[key]
         return inputs
 
     @abstractmethod
     def save(self, df: DataFrame) -> None:
-        pass
+        raise NotImplementedError()
 
     @abstractmethod
     def save_many(self, datasets: dataset_group) -> None:
-        pass
+        raise NotImplementedError()

--- a/src/atc/etl/orchestrator.py
+++ b/src/atc/etl/orchestrator.py
@@ -1,8 +1,9 @@
-from typing import List
+from typing import List, Union
 
 from pyspark.sql import DataFrame
 
-from .types import EtlBase, dataset_group
+from .types import dataset_group
+from .etl import EtlBase
 
 
 class Orchestrator:
@@ -24,11 +25,16 @@ class Orchestrator:
     transform_with = step
     load_into = step
 
-    def execute(self) -> DataFrame:
+    def execute(self) -> Union[DataFrame, None]:
         datasets: dataset_group = {}
         for step in self.steps:
             datasets = step.etl(datasets)
 
         if len(datasets) == 1:
             return next(iter(datasets.values()))
-        raise AssertionError("Multiple datasets in play at the end of orchestration.")
+        if not len(datasets):
+            return None
+        else:
+            raise AssertionError(
+                "Multiple datasets in play at the end of orchestration."
+            )

--- a/src/atc/etl/transformer.py
+++ b/src/atc/etl/transformer.py
@@ -2,7 +2,8 @@ from abc import abstractmethod
 
 from pyspark.sql import DataFrame
 
-from .types import dataset_group, EtlBase
+from .types import dataset_group
+from .etl import EtlBase
 
 
 class Transformer(EtlBase):
@@ -28,8 +29,8 @@ class Transformer(EtlBase):
 
     @abstractmethod
     def process(self, df: DataFrame) -> DataFrame:
-        return df
+        raise NotImplementedError()
 
     @abstractmethod
     def process_many(self, datasets: dataset_group) -> DataFrame:
-        pass
+        raise NotImplementedError()

--- a/src/atc/etl/types.py
+++ b/src/atc/etl/types.py
@@ -1,12 +1,5 @@
-from abc import abstractmethod
 from typing import Dict
 
 from pyspark.sql import DataFrame
 
 dataset_group = Dict[str, DataFrame]
-
-
-class EtlBase:
-    @abstractmethod
-    def etl(self, inputs: dataset_group) -> dataset_group:
-        pass

--- a/tests/etl/test_loader.py
+++ b/tests/etl/test_loader.py
@@ -10,35 +10,73 @@ from atc.spark import Spark
 class LoaderTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-
-        cls.loader = Loader()
-        cls.loader.save = MagicMock()
-        cls.loader.save_many = MagicMock()
-
         cls.df = create_dataframe()
 
-    def test_save_single(self):
+    def test_save_single_anon(self):
+
+        loader = Loader()
+        loader.save = MagicMock()
 
         input = {"myset": self.df}
-        result = self.loader.etl(input)
+        result = loader.etl(input)
 
         # assert that loader returns something:
         self.assertIs(input, result)
 
-        args = self.loader.save.call_args[
-            0
-        ]  # the .args part became available in python 3.8
+        args = loader.save.call_args[0]
+        # the .args part became available in python 3.8
+
         print(args)
         self.assertEqual(len(args), 1)
         self.assertIs(args[0], self.df)
 
-    def test_save_many(self):
+    def test_save_many_anon(self):
 
-        self.loader.etl({"myset1": self.df, "myset2": self.df})
+        loader = Loader()
+        loader.save_many = MagicMock()
 
-        args = self.loader.save_many.call_args[
-            0
-        ]  # the .args part became available in python 3.8
+        loader.etl({"myset1": self.df, "myset2": self.df})
+
+        args = loader.save_many.call_args[0]
+        # the .args part became available in python 3.8
+
+        print(args)
+        self.assertEqual(len(args), 1)
+        datasets = args[0]
+        self.assertEqual(len(datasets), 2)
+        self.assertEqual(set(datasets.keys()), {"myset1", "myset2"})
+
+    def test_save_single_consuming(self):
+
+        loader = Loader("myset")
+        loader.save = MagicMock()
+
+        input = {"myset": self.df}
+        result = loader.etl(input)
+
+        # assert that loader returns nothing:
+        self.assertEqual({}, result)
+
+        args = loader.save.call_args[0]
+        # the .args part became available in python 3.8
+
+        print(args)
+        self.assertEqual(len(args), 1)
+        self.assertIs(args[0], self.df)
+
+    def test_save_many_consuming(self):
+
+        loader = Loader("myset1", "myset2")
+        loader.save_many = MagicMock()
+
+        result = loader.etl({"myset1": self.df, "myset2": self.df, "other": "dummy"})
+
+        # assert that loader consumes its keys:
+        self.assertEqual({"other": "dummy"}, result)
+
+        args = loader.save_many.call_args[0]
+        # the .args part became available in python 3.8
+
         print(args)
         self.assertEqual(len(args), 1)
         datasets = args[0]


### PR DESCRIPTION
The loader can now consume its inputs. The important side-effect is that it is possible to have multiple load steps that consume different parts of the output.

### Example-7

In some cases a single destination dataset is not sufficient, as seen in this example.
Here we need to use the full power of the EtlBase class to return multiple datasets that
are then loaded by separate loaders.

Note that setting a key in the loader constructor allows it to pick out only one of the
inputs to save.

```
import pyspark.sql.types as t
from pyspark.sql import DataFrame

from atc.etl import Extractor, Loader, Orchestrator, EtlBase
from atc.etl.types import dataset_group
from atc.spark import Spark


class OrdersExtractor(Extractor):
    def __init__(self):
        super().__init__(dataset_key="orders")

    def read(self) -> DataFrame:
        spark = Spark.get()
        return spark.createDataFrame(
            Spark.get().sparkContext.parallelize(
                [
                    (1, "Guitar", 50),
                    (2, "Telescope", 200),
                    (3, "Tablet", 100),
                ]
            ),
            t._parse_datatype_string(
                """
                id INTEGER,
                product STRING,
                price INTEGER
            """
            ),
        )


class PaymentsExtractor(Extractor):
    def __init__(self):
        super().__init__(dataset_key="payments")

    def read(self) -> DataFrame:
        spark = Spark.get()
        return spark.createDataFrame(
            Spark.get().sparkContext.parallelize(
                [
                    (45, 1, 50),
                    (46, 2, 200),
                    (47, 3, 150),
                ]
            ),
            t._parse_datatype_string(
                """
                id INTEGER,
                order_id INTEGER,
                charged_amount INTEGER
            """
            ),
        )


class ReconcilingTransformer(EtlBase):
    def etl(self, inputs: dataset_group) -> dataset_group:
        orders = inputs["orders"]
        payments = inputs["payments"]

        df = orders.join(payments, orders.id == payments.order_id, "left").select(
            orders.id.alias("order_id"),
            payments.id.alias("payment_id"),
            orders.product,
            orders.price,
            payments.charged_amount,
        )

        dispatch = df.filter(df.price == df.charged_amount)
        service_follow_up = df.filter(~(df.price == df.charged_amount))

        return {"dispatch": dispatch, "service_follow_up": service_follow_up}


class DispatchLoader(Loader):
    def __init__(self):
        super().__init__("dispatch")

    def save(self, df: DataFrame) -> None:
        assert df.count() == 2
        print("Orders ready to dispatch:")
        df.show()


class CustomerServiceLoader(Loader):
    def __init__(self):
        super().__init__("service_follow_up")

    def save(self, df: DataFrame) -> None:
        assert df.count() == 1
        print("Orders that need follow-up:")
        df.show()


print("ETL Orchestrator using multiple different loaders")
etl = (
    Orchestrator()
    .extract_from(OrdersExtractor())
    .extract_from(PaymentsExtractor())
    .transform_with(ReconcilingTransformer())
    .load_into(DispatchLoader())
    .load_into(CustomerServiceLoader())
)
result = etl.execute()

```

Result:
```
Orders ready to dispatch:
+--------+----------+---------+-----+--------------+
|order_id|payment_id|  product|price|charged_amount|
+--------+----------+---------+-----+--------------+
|       2|        46|Telescope|  200|           200|
|       1|        45|   Guitar|   50|            50|
+--------+----------+---------+-----+--------------+

Orders that need follow-up:
+--------+----------+-------+-----+--------------+
|order_id|payment_id|product|price|charged_amount|
+--------+----------+-------+-----+--------------+
|       3|        47| Tablet|  100|           150|
+--------+----------+-------+-----+--------------+
```
