### PR TITLE
abstract methods raise not implemented error

### DIFF
--- a/src/atc/etl/extractor.py
+++ b/src/atc/etl/extractor.py
@@ -28,4 +28,4 @@ class Extractor(EtlBase):
 
     @abstractmethod
     def read(self) -> DataFrame:
-        pass
+        raise NotImplementedError()

--- a/src/atc/etl/loader.py
+++ b/src/atc/etl/loader.py
@@ -24,8 +24,8 @@ class Loader(EtlBase):
 
     @abstractmethod
     def save(self, df: DataFrame) -> None:
-        pass
+        raise NotImplementedError()
 
     @abstractmethod
     def save_many(self, datasets: dataset_group) -> None:
-        pass
+        raise NotImplementedError()

--- a/src/atc/etl/transformer.py
+++ b/src/atc/etl/transformer.py
@@ -28,8 +28,8 @@ class Transformer(EtlBase):
 
     @abstractmethod
     def process(self, df: DataFrame) -> DataFrame:
-        return df
+        raise NotImplementedError()
 
     @abstractmethod
     def process_many(self, datasets: dataset_group) -> DataFrame:
-        pass
+        raise NotImplementedError()

--- a/src/atc/etl/types.py
+++ b/src/atc/etl/types.py
@@ -9,4 +9,4 @@ dataset_group = Dict[str, DataFrame]
 class EtlBase:
     @abstractmethod
     def etl(self, inputs: dataset_group) -> dataset_group:
-        pass
+        raise NotImplementedError()


### PR DESCRIPTION
I once accidentally implemented the wrong abstract method. I implement a `Transformer.transform` and wondered why my transformation was not applied. I think that not implementing one of the abstract methods should raise.

This caused controversy so let's review it as a topic on its own.

Note: Merging into other feature branch with breaking changes.

