### PR TITLE
no return orchestrator

### DIFF
--- a/docs/etl/README.md
+++ b/docs/etl/README.md
@@ -89,6 +89,8 @@ class BasicTransformer(Transformer):
 class NoopLoader(Loader):
     def save(self, df: DataFrame) -> None:
         df.write.format("noop").mode("overwrite").save()
+        df.printSchema()
+        df.show()
 
 
 print("ETL Orchestrator using a single simple transformer")
@@ -98,9 +100,7 @@ etl = (
     .transform_with(BasicTransformer())
     .load_into(NoopLoader())
 )
-result = etl.execute()
-result.printSchema()
-result.show()
+etl.execute()
 
 ```
 
@@ -178,6 +178,8 @@ class IntegerColumnTransformer(Transformer):
 class NoopLoader(Loader):
     def save(self, df: DataFrame) -> None:
         df.write.format("noop").mode("overwrite").save()
+        df.printSchema()
+        df.show()
 
 
 print("ETL Orchestrator using multiple transformers")
@@ -188,9 +190,7 @@ etl = (
     .transform_with(IntegerColumnTransformer("year"))
     .load_into(NoopLoader())
 )
-result = etl.execute()
-result.printSchema()
-result.show()
+etl.execute()
 
 ```
 
@@ -263,6 +263,8 @@ class CountryOfOriginTransformer(Transformer):
 class NoopLoader(Loader):
     def save(self, df: DataFrame) -> None:
         df.write.format("noop").mode("overwrite").save()
+        df.printSchema()
+        df.show()
 
 
 print("ETL Orchestrator using multiple extractors")
@@ -273,9 +275,7 @@ etl = (
     .transform_with(CountryOfOriginTransformer())
     .load_into(NoopLoader())
 )
-result = etl.execute()
-result.printSchema()
-result.show()
+etl.execute()
 
 ```
 
@@ -327,13 +327,13 @@ class GuitarExtractor(Extractor):
 class NoopLoader(Loader):
     def save(self, df: DataFrame) -> None:
         df.write.format("noop").mode("overwrite").save()
+        df.printSchema()
+        df.show()
 
 
 print("ETL Orchestrator with no transformations")
 etl = Orchestrator().extract_from(GuitarExtractor()).load_into(NoopLoader())
-result = etl.execute()
-result.printSchema()
-result.show()
+etl.execute()
 
 ```
 
@@ -392,6 +392,8 @@ class NoopSilverLoader(Loader):
 class NoopGoldLoader(Loader):
     def save(self, df: DataFrame) -> None:
         df.write.format("noop").mode("overwrite").save()
+        df.printSchema()
+        df.show()
 
 
 print("ETL Orchestrator using multiple loaders")
@@ -402,9 +404,7 @@ etl = (
     .load_into(NoopSilverLoader())
     .load_into(NoopGoldLoader())
 )
-result = etl.execute()
-result.printSchema()
-result.show()
+etl.execute()
 
 ```
 
@@ -493,6 +493,8 @@ class NoopSilverLoader(Loader):
 class NoopGoldLoader(Loader):
     def save(self, df: DataFrame) -> None:
         df.write.format("noop").mode("overwrite").save()
+        df.printSchema()
+        df.show()
 
 
 print("ETL Orchestrator using multiple loaders")
@@ -505,8 +507,6 @@ etl = (
     .load_into(NoopSilverLoader())
     .load_into(NoopGoldLoader())
 )
-result = etl.execute()
-result.printSchema()
-result.show()
+etl.execute()
 
 ```

--- a/examples/etl/basic_example.py
+++ b/examples/etl/basic_example.py
@@ -41,6 +41,8 @@ class BasicTransformer(Transformer):
 class NoopLoader(Loader):
     def save(self, df: DataFrame) -> None:
         df.write.format("noop").mode("overwrite").save()
+        df.printSchema()
+        df.show()
 
 
 print("ETL Orchestrator using a single simple transformer")
@@ -50,6 +52,4 @@ etl = (
     .transform_with(BasicTransformer())
     .load_into(NoopLoader())
 )
-result = etl.execute()
-result.printSchema()
-result.show()
+etl.execute()

--- a/examples/etl/multi_multi_example.py
+++ b/examples/etl/multi_multi_example.py
@@ -73,6 +73,8 @@ class NoopSilverLoader(Loader):
 class NoopGoldLoader(Loader):
     def save(self, df: DataFrame) -> None:
         df.write.format("noop").mode("overwrite").save()
+        df.printSchema()
+        df.show()
 
 
 print("ETL Orchestrator using multiple loaders")
@@ -85,6 +87,4 @@ etl = (
     .load_into(NoopSilverLoader())
     .load_into(NoopGoldLoader())
 )
-result = etl.execute()
-result.printSchema()
-result.show()
+etl.execute()

--- a/examples/etl/multiple_input_example.py
+++ b/examples/etl/multiple_input_example.py
@@ -56,6 +56,8 @@ class CountryOfOriginTransformer(Transformer):
 class NoopLoader(Loader):
     def save(self, df: DataFrame) -> None:
         df.write.format("noop").mode("overwrite").save()
+        df.printSchema()
+        df.show()
 
 
 print("ETL Orchestrator using multiple extractors")
@@ -66,6 +68,4 @@ etl = (
     .transform_with(CountryOfOriginTransformer())
     .load_into(NoopLoader())
 )
-result = etl.execute()
-result.printSchema()
-result.show()
+etl.execute()

--- a/examples/etl/multiple_output_example.py
+++ b/examples/etl/multiple_output_example.py
@@ -48,6 +48,8 @@ class NoopSilverLoader(Loader):
 class NoopGoldLoader(Loader):
     def save(self, df: DataFrame) -> None:
         df.write.format("noop").mode("overwrite").save()
+        df.printSchema()
+        df.show()
 
 
 print("ETL Orchestrator using multiple loaders")
@@ -58,6 +60,4 @@ etl = (
     .load_into(NoopSilverLoader())
     .load_into(NoopGoldLoader())
 )
-result = etl.execute()
-result.printSchema()
-result.show()
+etl.execute()

--- a/examples/etl/multiple_transform_example.py
+++ b/examples/etl/multiple_transform_example.py
@@ -40,6 +40,8 @@ class IntegerColumnTransformer(Transformer):
 class NoopLoader(Loader):
     def save(self, df: DataFrame) -> None:
         df.write.format("noop").mode("overwrite").save()
+        df.printSchema()
+        df.show()
 
 
 print("ETL Orchestrator using multiple transformers")
@@ -50,6 +52,4 @@ etl = (
     .transform_with(IntegerColumnTransformer("year"))
     .load_into(NoopLoader())
 )
-result = etl.execute()
-result.printSchema()
-result.show()
+etl.execute()

--- a/examples/etl/no_transform_example.py
+++ b/examples/etl/no_transform_example.py
@@ -21,10 +21,10 @@ class GuitarExtractor(Extractor):
 class NoopLoader(Loader):
     def save(self, df: DataFrame) -> None:
         df.write.format("noop").mode("overwrite").save()
+        df.printSchema()
+        df.show()
 
 
 print("ETL Orchestrator with no transformations")
 etl = Orchestrator().extract_from(GuitarExtractor()).load_into(NoopLoader())
-result = etl.execute()
-result.printSchema()
-result.show()
+etl.execute()

--- a/src/atc/etl/orchestrator.py
+++ b/src/atc/etl/orchestrator.py
@@ -24,11 +24,7 @@ class Orchestrator:
     transform_with = step
     load_into = step
 
-    def execute(self) -> DataFrame:
+    def execute(self) -> None:
         datasets: dataset_group = {}
         for step in self.steps:
             datasets = step.etl(datasets)
-
-        if len(datasets) == 1:
-            return next(iter(datasets.values()))
-        raise AssertionError("Multiple datasets in play at the end of orchestration.")


### PR DESCRIPTION
In some cases I need a multi-return orchestrator. An orchestrator may contain a many-to-many transformation with several `save_many` loaders. The result will be several remaing datasets in the group.
It is not clear which, if any, datasets the orchestrator should return in this case. The logical consequence is that it should return none.

Note: Meging into 0.5 feature branch