### PR TITLE
api auto config

### DIFF
--- a/docs/utilities/README.md
+++ b/docs/utilities/README.md
@@ -2,8 +2,21 @@
 
 Utilities in atc-dataplatform:
 
+* [Api Auto Config](#api-auto-config)
 * [Test Utilities](#test-utilities)
 * [Git Hooks](#git-hooks)
+
+## Api Auto Config
+
+Using the method `atc.db_auto.getDbApi()` gives access to a 
+`DatabricksAPI` instance thas has been pre-configured for the 
+current databricks instance. See [databricks-api](https://pypi.org/project/databricks-api/)
+for usage documentation.
+
+Under the hood the function uses the job context to get the host and token
+when on the cluster. When using `atc` with databricks-connect, the `databricks-cli` is
+called to configure the client. Thus the function works without further configuration
+in all contexts.
 
 ## Test Utilities
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.7",
-    install_requires=["pyyaml", "sqlparse", "deprecation", "pyodbc"],
+    install_requires=["pyyaml", "sqlparse", "deprecation", "pyodbc", "databricks-api"],
     extras_require={
         "dev": ["check-manifest"],
         # 'test': ['coverage'],

--- a/src/atc/db_auto.py
+++ b/src/atc/db_auto.py
@@ -1,0 +1,45 @@
+"""Simplified access to the databricks api."""
+
+import json
+import sys
+
+from databricks_api import DatabricksAPI
+
+from atc.functions import init_dbutils
+
+
+def getDbApi() -> DatabricksAPI:
+    """
+    This method automatically configures a databricks API client.
+    In local running, the databricks-cli is used for configuration.
+    Running on a cluster, the configuration is extracted from the job context.
+    """
+    try:
+        dbutils = init_dbutils()
+    except ModuleNotFoundError:
+        # probably we are not in notebook
+        dbutils = None
+
+    if dbutils:
+        context = json.loads(
+            dbutils.notebook.entry_point.getDbutils().notebook().getContext().toJson()
+        )
+        host = context["extraContext"]["api_url"]
+        token = context["extraContext"]["api_token"]
+    else:
+        try:
+            from databricks_cli.configure.provider import ProfileConfigProvider
+        except ModuleNotFoundError:
+            print(
+                "In local running, databricks-cli needs to be installed.",
+                file=sys.stderr,
+            )
+            raise
+        cfg = ProfileConfigProvider().get_config()
+        host = cfg.host
+        token = cfg.token
+
+    if not host or not token:
+        raise Exception("Unable to auto-configure api client.")
+
+    return DatabricksAPI(host=host, token=token)

--- a/tests/cluster/db/test_db_api.py
+++ b/tests/cluster/db/test_db_api.py
@@ -1,0 +1,12 @@
+import unittest
+
+from atc.db_auto import getDbApi
+
+
+class ApiTests(unittest.TestCase):
+    def test_01_configureApi(self):
+        db = getDbApi()
+
+    def test_02_make_a_call(self):
+        db = getDbApi()
+        self.assertIn("files", db.dbfs.list("/"))


### PR DESCRIPTION
## Api Auto Config

Using the method `atc.db_auto.getDbApi()` gives access to a 
`DatabricksAPI` instance thas has been pre-configured for the 
current databricks instance. See [databricks-api](https://pypi.org/project/databricks-api/)
for usage documentation.

Under the hood the function uses the job context to get the host and token
when on the cluster. When using `atc` with databricks-connect, the `databricks-cli` is
called to configure the client. Thus the function works without further configuration
in all contexts.
