### PR TITLE
convenience etl

### DIFF
--- a/docs/etl/specializations/README.md
+++ b/docs/etl/specializations/README.md
@@ -62,3 +62,25 @@ Therefore, this method needs to return the rows that were actually deleted,
 (or return `None`). The cache loader takes the returned rows and
 updates the cache table with them, to mark them as having been deleted.
 returning `None` here skips the rest of the deleting logic.
+
+## Simple Extrator/Loader
+
+Often the step of extracting from, e.g. a delta handle or an eventhub,
+can be so simple that is seems superfluous to use the etl framework. For
+these cases a simple extractor and simple loader have been provided.
+Any object with a `.read()` method can be passed to the `SimpleExtractor`.
+Any object with a `.overwrite(df)` of a `.append(df)` method can be passed
+to the `SimpleLoader`. See the following example:
+```python
+from atc.eh import EventHubCapture
+from atc.delta import DeltaHandle
+from atc.etl.loaders import SimpleLoader
+from atc.etl.extractors import SimpleExtractor
+from atc.etl import Orchestrator
+
+class MyOrchestrator(Orchestrator):
+  def __init__(self):
+    super().__init__()
+    self.extract_from(EventHubCapture.from_tc("MyEhDefinition"))
+    self.load_into(DeltaHandle.from_tc("MyDeltaTable"))
+```

--- a/src/atc/etl/extractors/__init__.py
+++ b/src/atc/etl/extractors/__init__.py
@@ -1,0 +1,1 @@
+from .simple_extractor import SimpleExtractor  # noqa: F401

--- a/src/atc/etl/extractors/simple_extractor.py
+++ b/src/atc/etl/extractors/simple_extractor.py
@@ -1,0 +1,21 @@
+from typing import Protocol
+
+from pyspark.sql import DataFrame
+
+from atc.etl import Extractor
+
+
+class Readable(Protocol):
+    def read(self) -> DataFrame:
+        pass
+
+
+class SimpleExtractor(Extractor):
+    """This extractor will extract from any object that has a .read() method."""
+
+    def __init__(self, handle: Readable, dataset_key: str):
+        super().__init__(dataset_key=dataset_key)
+        self.handle = handle
+
+    def read(self) -> DataFrame:
+        return self.handle.read()

--- a/src/atc/etl/loaders/__init__.py
+++ b/src/atc/etl/loaders/__init__.py
@@ -1,0 +1,1 @@
+from .simple_loader import SimpleLoader  # noqa: F401

--- a/src/atc/etl/loaders/simple_loader.py
+++ b/src/atc/etl/loaders/simple_loader.py
@@ -1,0 +1,30 @@
+from typing import Protocol, Union
+
+from pyspark.sql import DataFrame
+
+from atc.etl import Loader
+
+
+class Overwritable(Protocol):
+    def overwrite(self, df: DataFrame) -> None:
+        pass
+
+
+class Appendable(Protocol):
+    def append(self, df: DataFrame) -> None:
+        pass
+
+
+class SimpleLoader(Loader):
+    def __init__(
+        self, handle: Union[Overwritable, Appendable], *, mode: str = "overwrite"
+    ):
+        super().__init__()
+        self.mode = mode
+        self.handle = handle
+
+    def save(self, df: DataFrame) -> None:
+        if self.mode == "overwrite":
+            self.handle.overwrite(df)
+        else:
+            self.handle.append(df)

--- a/tests/cluster/delta/test_delta_class.py
+++ b/tests/cluster/delta/test_delta_class.py
@@ -4,6 +4,9 @@ from pyspark.sql.utils import AnalysisException
 
 from atc.config_master import TableConfigurator
 from atc.delta import DbHandle, DeltaHandle
+from atc.etl import Orchestrator
+from atc.etl.extractors import SimpleExtractor
+from atc.etl.loaders import SimpleLoader
 from atc.spark import Spark
 
 
@@ -70,7 +73,15 @@ class DeltaTests(unittest.TestCase):
         df = dh.read()
         self.assertEqual(0, df.count())
 
-    def test_06_delete(self):
+    def test_06_etl(self):
+        o = Orchestrator()
+        o.extract_from(
+            SimpleExtractor(DeltaHandle.from_tc("MyTbl"), dataset_key="MyTbl")
+        )
+        o.load_into(SimpleLoader(DeltaHandle.from_tc("MyTbl"), mode="overwrite"))
+        o.execute()
+
+    def test_07_delete(self):
         dh = DeltaHandle.from_tc("MyTbl")
         dh.drop_and_delete()
 


### PR DESCRIPTION
## Simple Extrator/Loader

Often the step of extracting from, e.g. a delta handle or an eventhub,
can be so simple that is seems superfluous to use the etl framework. For
these cases a simple extractor and simple loader have been provided.
Any object with a `.read()` method can be passed to the `SimpleExtractor`.
Any object with a `.overwrite(df)` of a `.append(df)` method can be passed
to the `SimpleLoader`. See the following example:
```python
from atc.eh import EventHubCapture
from atc.delta import DeltaHandle
from atc.etl.loaders import SimpleLoader
from atc.etl.extractors import SimpleExtractor
from atc.etl import Orchestrator

class MyOrchestrator(Orchestrator):
  def __init__(self):
    super().__init__()
    self.extract_from(EventHubCapture.from_tc("MyEhDefinition"))
    self.load_into(DeltaHandle.from_tc("MyDeltaTable"))
```