### PR TITLE
dbx update fix

### DIFF
--- a/.github/deploy/steps/99-SetupMounts.ps1
+++ b/.github/deploy/steps/99-SetupMounts.ps1
@@ -6,7 +6,6 @@ Push-Location -Path $srcDir
 pip install dbx
 
 dbx configure
-copy "$srcDir/.github/submit/sparklibs.json" "$srcDir/tests/cluster/mount/"
 
 dbx deploy --deployment-file  "$srcDir/tests/cluster/mount/setup_job.yml.j2"
 

--- a/tests/cluster/mount/setup_job.yml.j2
+++ b/tests/cluster/mount/setup_job.yml.j2
@@ -19,7 +19,7 @@ custom:
     node_type_id: "Standard_DS3_v2"
     num_workers: 0
 
-  spark-libs: &spark-libs {% include 'sparklibs.json' %}
+  spark-libs: &spark-libs {% include '.github/submit/sparklibs.json' %}
 
 
 environments:

--- a/tests/cluster/mount/sparklibs.json
+++ b/tests/cluster/mount/sparklibs.json
@@ -1,1 +1,0 @@
-This file is overwritten as part of the deployment pipeline.


### PR DESCRIPTION
With the latest update [dbx now supports templates in subfolders](https://github.com/databrickslabs/dbx/blob/main/CHANGELOG.md#050---2022-06-01).

At the same time, automatically importing the template from the same folder as the file now fails. Hence we had to update.