### PR TITLE
Feature/recursive table details

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -1,0 +1,105 @@
+
+# Table Configurator
+
+## Motivation
+In databricks there is one standard way to refer to a table, the 
+"database.table" reference. In our dataplatform projects we have often 
+found a need for a more abstracted notion of a table reference,
+one that allows for injection of test versions of tables and that allows 
+unified reference across different environments (dev, staging, prod).
+The `TableConfigurator` provides such a further abstraction level.
+
+## Setting up configuration
+
+The `TableConfigurator` is a singleton class that you need to instantiate
+and configure once in your project. Make sure this code is always executed
+before any reference to tables in made. Example:
+```python
+from atc.config_master import TableConfigurator
+tc = TableConfigurator()
+tc.set_extra(ENV='prod')
+tc.add_resource_path(my.resource.module)
+```
+The `TableConfigurator` can be configured with json or yaml files. The
+files must contain the following structure:
+- top level objects are resources
+- each resource must have one of three shapes:
+  - a single key named 'alias' to refer to another resource
+  - two keys called 'release' and 'debug', each containing resource details
+  - resource details consisting of a 'name' attribute
+    - optionally also with a 'path' attribute,
+    - optionally also with a 'format' and 'partitioning' attribute.
+You can see examples for all three cases in the unit-tests.
+
+You optionally either provide 'release' and 'debug' versions of each table
+or include the structure `{ID}` in the name and path. This is a special
+replacement string that will be replaced with and empty string for 
+production tables, or with a "__{GUID}" string when debug is selected.
+The guid construction allows for non-colliding parallel testing.
+
+Beyond the resource definitions, the `TableConfigurator` needs to be 
+configured to return production or test versions of tables this is done
+at the start of your code. In you jobs you need to set `TableConfigurator().set_prod()`
+whereas your unit-tests should call `TableConfigurator().set_debug()`.
+
+## Using the TableConfigurator
+
+Once configured, the table configurator is often not used directly.
+Other classes in the atc framework use it when configured with a resource
+ID. You can find examples in the eventhub unittests:
+```python
+from atc.eh import EventHubCapture
+EventHubCapture.from_tc("AtcEh")
+```
+or in the delta handle unit-tests:
+```python
+from atc.delta import DeltaHandle
+DeltaHandle.from_tc("MyTbl")
+```
+But sometimes you still need to call the table configurator methods
+e.g. when constructing your own sql:
+```python
+from atc.config_master import TableConfigurator
+f"MERGE INTO {TableConfigurator().table_name('MyTbl')} AS target ..."
+```
+
+## Further Features
+
+### MNT key
+'MNT' is another special replacement, similar to "ID". In production it
+is replaced with the string 'mnt' while in debug it is replace with 'tmp'.
+The intended usage is in paths where production tables are mounted on
+external storage, typically mounted under "/mnt" whereas test tables 
+should be written to "/tmp" you can use is as in this example:
+```yaml
+MyTable:
+  name: mydb{ID}.data_table
+  path: /{MNT}/somestorage{ENV}/mydb{ID}/data_table
+```
+
+### Cross References
+In some cases it is useful to refer to other defined resources and their properties.
+This is fully supported as shown here:
+```yaml
+MyDb:
+  name: mydb{ID}
+  path: /{MNT}/storage{ENV}/mydb{ID}
+
+MyTable:
+  name: {MyDb}.mytable
+  path: {MyDb_path}/mytable
+```
+As shown here the "name" property can be accessed with the bare resouce key
+whereas other properties can be accessed by appending the property with an 
+underscore. (Optionally, appending "_name" is also supported to access the
+name, i.e. `{MyDb}` and `{MyDb_name}` are equivalent.)
+
+### Extra details
+As already shown in the example above, there is a method to add
+further extra details such as an 'ENV' key. Note: The ENV key is not 
+a built-in special property. Use the `set_extra` method:
+```python
+from atc.config_master import TableConfigurator
+tc = TableConfigurator()
+tc.set_extra(ENV='prod')
+```

--- a/src/atc/config_master/table_configurator.py
+++ b/src/atc/config_master/table_configurator.py
@@ -168,6 +168,8 @@ class TableConfigurator(metaclass=Singleton):
     ############################################
 
     def set_extra(self, **kwargs: str):
+        """Add extra replacement keys for your resources.
+        for example call .set_extra(ENV='prod')"""
         self._extra_config.update(kwargs)
         self.table_details = dict()
 

--- a/src/atc/config_master/table_configurator.py
+++ b/src/atc/config_master/table_configurator.py
@@ -2,6 +2,7 @@ import importlib.resources
 import json
 import uuid
 from pathlib import Path
+from string import Formatter
 from types import ModuleType
 from typing import Dict, Set, Union
 
@@ -10,64 +11,125 @@ import yaml
 from atc.config_master.exceptions import UnknownShapeException
 from atc.singleton import Singleton
 
+from ..atc_exceptions import AtcException
 from .configuration_types import (
     AnyDetails,
     TableAlias_keys,
-    TableDetailsExtended,
     TableDetailsExtended_keys,
-    TableRelDbg,
     TableRelDbg_keys,
 )
 
 
+class NoSuchPropertyException(AtcException):
+    pass
+
+
 class TableConfigurator(metaclass=Singleton):
-    unique_id: str
-    table_names: Dict[str, AnyDetails]
-    table_arguments: Dict[str, str]
-    resource_paths: Set[Union[str, ModuleType]]
-    extra_config: Dict[str, str]
+    _unique_id: str
+    _raw_resource_details: Dict[str, AnyDetails]
+    _is_debug: bool
+    _extra_config: Dict[str, str]
+
+    # this dict contains all details for all resources
+    table_details: Dict[str, str]
 
     def __init__(self, resource_path: Union[str, ModuleType] = None):
-        self.unique_id = uuid.uuid4().hex
-        self.resource_paths = set()
-        self.table_names = dict()
-        self.extra_config = dict()
+        self._unique_id = uuid.uuid4().hex
+        self.clear_all_configurations()
 
         if resource_path:
             self.add_resource_path(resource_path)
 
-        self.__reset()
+    def clear_all_configurations(self):
+        self._raw_resource_details = dict()
+        self._extra_config = dict()
+        self._is_debug = False
+        self.table_details = dict()
+
+    ############################################
+    # the core logic of this class is contained
+    # in the following methods
+    ############################################
+
+    def get_extra_details(self) -> Dict[str, str]:
+        """get all special substitutions not based on resources"""
+        extras = {
+            "ID": "__{self.unique_id}" if self._is_debug else "",
+            "MNT": "tmp" if self._is_debug else "mnt",
+        }
+        extras.update(self._extra_config)
+        return extras
+
+    def _get_item_property(
+        self, table_id: str, property: str, _forbidden_keys: Set[str] = None
+    ) -> str:
+        """Get the full item property, fully resolved and substituted."""
+        raw_string = self._get_unsubstituted_item_property(table_id, property)
+
+        replacements = self.get_extra_details()
+        format_keys = [i[1] for i in Formatter().parse(raw_string) if i[1] is not None]
+        other_resource_keys = set(format_keys) - set(replacements.keys())
+
+        # the forbidden-keys logic allows us to detect reference loops.
+        # no key that is in the upstream of a property is allowed in the string
+        # substitutions of this property.
+        _forbidden_keys = _forbidden_keys or set()
+        _forbidden_keys.add(f"{table_id}_{property}")
+        if property == "name":
+            _forbidden_keys.add(table_id)
+        if any(key in _forbidden_keys for key in other_resource_keys):
+            raise ValueError(
+                f"Substitution loop at table {table_id} property {property}"
+            )
+
+        # every key that is not in the special properties and not forbidden
+        # should refer to another resource. If it does not an exception will occur.
+        for key in other_resource_keys:
+            if key.endswith("_path"):
+                replacements[key] = self._get_item_property(
+                    key[:-5], "path", _forbidden_keys
+                )
+            elif key.endswith("_name"):
+                replacements[key] = self._get_item_property(
+                    key[:-5], "name", _forbidden_keys
+                )
+            else:
+                replacements[key] = self._get_item_property(
+                    key, "name", _forbidden_keys
+                )
+
+        return raw_string.format(**replacements)
+
+    def _get_unsubstituted_item_property(self, table_id: str, property: str) -> str:
+        """item property where release-debug and alias loops are resolved"""
+        # this stack allows us to detect alias loop
+        stack = {table_id}
+
+        value = self._raw_resource_details[table_id]
+        while ("release" in value) or ("debug" in value) or ("alias" in value):
+            if ("release" in value) or ("debug" in value):
+                # Handle the case of differentiated release and debug tables
+                if self._is_debug:
+                    value = value["debug"]
+                else:
+                    value = value["release"]
+
+            if "alias" in value:  # allow alias of alias
+                new_id = value["alias"]
+                if new_id in stack:
+                    raise ValueError(f"Alias loop at key {new_id}")
+                stack.add(new_id)
+                value = self._raw_resource_details[new_id]
+
+        # we are finished resolving a possible route of aliases
+        if property in value:
+            return value[property]
+        else:
+            raise NoSuchPropertyException(property)
 
     def add_resource_path(self, resource_path: Union[str, ModuleType]) -> None:
-        self.resource_paths.add(resource_path)
-
-    def clear_all_configurations(self):
-        self.resource_paths = set()
-        self.table_names = dict()
-        self.extra_config = dict()
-        self.__reset()
-
-    def set_extra(self, **kwargs: str):
-        self.extra_config.update(kwargs)
-
-    def set_debug(self):
-        """Select debug tables. {ID} will be replaced with a guid"""
-        self.reset(debug=True)
-
-    def set_prod(self):
-        """Select production tables. {ID} will be replaced with a empty string"""
-        self.reset(debug=False)
-
-    def __reset(self, debug: bool = False, **kwargs: str) -> None:
-        self._is_debug = debug
-        self.table_arguments = dict()
-        self.table_arguments["MNT"] = "tmp" if debug else "mnt"
-        self.table_arguments["ID"] = f"__{self.unique_id}" if debug else ""
-        self.table_arguments.update(self.extra_config)
-        self.table_arguments.update(kwargs)
-
-        self.table_names = dict()
-        for resource_path in self.resource_paths:
+        backup_details = self._raw_resource_details.copy()
+        try:
             for file_name in importlib.resources.contents(resource_path):
                 extension = Path(file_name).suffix
                 if extension in [".json", ".yaml", ".yml"]:
@@ -85,15 +147,41 @@ class TableConfigurator(metaclass=Singleton):
 
                             for key, value in update.items():
                                 if self.__is_known_shape(value):
-                                    self.table_names[key] = value
+                                    self._raw_resource_details[key] = value
                                 else:
                                     raise UnknownShapeException(
                                         f"Object {key} in file {file_path}"
                                         f" has unexpected shape."
                                     )
 
-        for key in self.table_names.keys():
-            self.__resolve_key(key)
+            # try re-building all details
+            self.table_details = dict()
+            self.get_all_details()
+        except:  # noqa: E722  we re-raise the exception, so bare except is ok.
+            # this piece makes it so that the TableConfigurator can still be used
+            # if any exception raised by the above code is caught.
+            self._raw_resource_details = backup_details
+            raise
+
+    ############################################
+    # all methods below are interface and convenience methods
+    ############################################
+
+    def set_extra(self, **kwargs: str):
+        self._extra_config.update(kwargs)
+        self.table_details = dict()
+
+    def set_debug(self):
+        """Select debug tables. {ID} will be replaced with a guid"""
+        self.reset(debug=True)
+
+    def set_prod(self):
+        """Select production tables. {ID} will be replaced with a empty string"""
+        self.reset(debug=False)
+
+    def __reset(self, debug: bool) -> None:
+        self._is_debug = debug
+        self.table_details = dict()
 
     def __is_TableDetails_shape(self, value):
         return set(value.keys()).issubset(TableDetailsExtended_keys)
@@ -111,49 +199,14 @@ class TableConfigurator(metaclass=Singleton):
             or self.__is_TableRelDbg_shape(value)
         )
 
-    def __resolve_key(self, key: str):
-        # Handle the case of differentiated release and debug tables
-        if self.__is_TableRelDbg_shape(self.table_names[key]):
-            value: TableRelDbg = self.table_names[key]
-            if self._is_debug:
-                self.table_names[key] = value["debug"]
-            else:
-                self.table_names[key] = value["release"]
-
-        # carry out string substitutions in name and path
-        if self.__is_TableDetails_shape(self.table_names[key]):
-            value: TableDetailsExtended = self.table_names[key]
-            if "name" in value:
-                self.table_names[key]["name"] = value["name"].format(
-                    **self.table_arguments
-                )
-            if "path" in value:
-                self.table_names[key]["path"] = value["path"].format(
-                    **self.table_arguments
-                )
-
-    def __get_name_entry(self, table_id: str):
-        entry = self.table_names[table_id]
-
-        # this stack allows us to detect alias loop
-        stack = {table_id}
-
-        while "alias" in entry:  # allow alias of alias
-            new_id = entry["alias"]
-            if new_id in stack:
-                raise ValueError(f"Alias loop at key {new_id}")
-            stack.add(new_id)
-            entry = self.table_names[new_id]
-        return entry
-
-    def reset(self, *, debug: bool = False, **kwargs):
+    def reset(self, *, debug: bool = False):
         """
         Resets table names and table SQL. Enables or disables debug mode
         (used for unit tests and integration tests).
         :param debug: False -> release tables, True -> debug tables.
         :param kwargs: additional keys to be substituted in names and paths
         """
-        self.__reset(debug, **kwargs)
+        self.__reset(debug)
 
     def is_debug(self):
         """
@@ -167,7 +220,7 @@ class TableConfigurator(metaclass=Singleton):
         Return the character length of the UUID identifier inserted into
         names with the {ID} tag
         """
-        return len(self.unique_id)
+        return len(self._unique_id)
 
     def register(self, key: str, value: AnyDetails):
         """
@@ -175,8 +228,8 @@ class TableConfigurator(metaclass=Singleton):
         """
         if not self.__is_known_shape(value):
             raise ValueError("Object has unexpected shape.")
-        self.table_names[key] = value
-        self.__resolve_key(key)
+        self._raw_resource_details[key] = value
+        self.table_details = dict()
 
     def table_property(
         self, table_id: str, property_name: str, default_value: str = None
@@ -190,9 +243,10 @@ class TableConfigurator(metaclass=Singleton):
             if the property is missing.
         :return: str: property value
         """
-        property_value = self.__get_name_entry(table_id).get(
-            property_name, default_value
+        property_value = self.get_all_details().get(
+            f"{table_id}_{property_name}", default_value
         )
+
         if property_value is None:
             raise ValueError(
                 f"property '{property_name}' for table identifier '{table_id}' is empty"
@@ -216,14 +270,34 @@ class TableConfigurator(metaclass=Singleton):
         return self.table_property(table_id, "path")
 
     def get_all_details(self):
-        table_objects = {}
-        for key in self.table_names.keys():
-            table = self.__get_name_entry(key)
+        """
+        Return a dictionary containing every resource detail fully resolved.
+        e.g. a resource that looks like this:
+        MyTableDetail:
+            name: mytablename
+            path: my/table/path
+        will appear with three keys:
+            - "MyTableDetail"
+            - "MyTableDetail_name"
+            - "MyTableDetail_path"
+        all substitutions will be fully resolved.
+        """
+        if not self.table_details:
+            self.table_details = dict()
 
-            for property, attribute in table.items():
-                table_objects[f"{key}_{property}"] = attribute
+            for table_id in self._raw_resource_details.keys():
+                try:
+                    self.table_details[table_id] = self._get_item_property(
+                        table_id, "name"
+                    )
+                except NoSuchPropertyException:
+                    pass
+                for property_name in TableDetailsExtended_keys:
+                    try:
+                        self.table_details[
+                            f"{table_id}_{property_name}"
+                        ] = self._get_item_property(table_id, property_name)
+                    except NoSuchPropertyException:
+                        pass
 
-            if f"{key}_name" in table_objects:
-                table_objects[key] = table_objects[f"{key}_name"]
-
-        return table_objects
+        return self.table_details

--- a/tests/local/config_master/tables1/tbl1.yml
+++ b/tests/local/config_master/tables1/tbl1.yml
@@ -13,3 +13,7 @@ MyForked:
     name: another
     path: /my/temp/path
 
+
+MyRecursing:
+  name: recursing{ID}
+  path: /{MNT}/tables/{MyRecursing_name}

--- a/tests/local/config_master/tables3/bad.yml
+++ b/tests/local/config_master/tables3/bad.yml
@@ -1,0 +1,8 @@
+
+
+LoopRecursion1:
+  name: loopy1{LoopRecursion2}
+
+LoopRecursion2:
+  name: loopy2{LoopRecursion1}
+

--- a/tests/local/config_master/test_table_configurator.py
+++ b/tests/local/config_master/test_table_configurator.py
@@ -2,7 +2,7 @@ import unittest
 
 from atc.config_master import TableConfigurator
 
-from . import tables1, tables2
+from . import tables1, tables2, tables3
 
 
 class TestTableConfigurator(unittest.TestCase):
@@ -32,14 +32,26 @@ class TestTableConfigurator(unittest.TestCase):
 
     def test_03_json(self):
         tc = TableConfigurator()
-        tc.add_resource_path(tables2)
 
         with self.assertRaises(KeyError):
-            tc.reset(debug=True)
+            tc.add_resource_path(tables2)
 
-        tc.reset(debug=True, ENV="dev")
+        tc.set_extra(ENV="dev")
+        tc.add_resource_path(tables2)
+        tc.reset(debug=True)
         self.assertRegex(tc.table_name("MyThird"), "first__.*")
 
         self.assertRegex(
             tc.get_all_details()["MyFourth_path"], "/tmp/dev/path/to/delta"
         )
+
+    def test_04_recursing(self):
+        tc = TableConfigurator()
+        tc.set_prod()
+        self.assertEqual(tc.table_path("MyRecursing"), "/mnt/tables/recursing")
+
+    def test_05_test_self_recursion_detection(self):
+        tc = TableConfigurator()
+        tc.set_prod()
+        with self.assertRaises(ValueError):
+            tc.add_resource_path(tables3)


### PR DESCRIPTION

# Table Configurator

## Motivation
In databricks there is one standard way to refer to a table, the 
"database.table" reference. In our dataplatform projects we have often 
found a need for a more abstracted notion of a table reference,
one that allows for injection of test versions of tables and that allows 
unified reference across different environments (dev, staging, prod).
The `TableConfigurator` provides such a further abstraction level.

## Setting up configuration

The `TableConfigurator` is a singleton class that you need to instantiate
and configure once in your project. Make sure this code is always executed
before any reference to tables in made. Example:
```python
from atc.config_master import TableConfigurator
tc = TableConfigurator()
tc.set_extra(ENV='prod')
tc.add_resource_path(my.resource.module)
```
The `TableConfigurator` can be configured with json or yaml files. The
files must contain the following structure:
- top level objects are resources
- each resource must have one of three shapes:
  - a single key named 'alias' to refer to another resource
  - two keys called 'release' and 'debug', each containing resource details
  - resource details consisting of a 'name' attribute
    - optionally also with a 'path' attribute,
    - optionally also with a 'format' and 'partitioning' attribute.
You can see examples for all three cases in the unit-tests.

You optionally either provide 'release' and 'debug' versions of each table
or include the structure `{ID}` in the name and path. This is a special
replacement string that will be replaced with and empty string for 
production tables, or with a "__{GUID}" string when debug is selected.
The guid construction allows for non-colliding parallel testing.

Beyond the resource definitions, the `TableConfigurator` needs to be 
configured to return production or test versions of tables this is done
at the start of your code. In you jobs you need to set `TableConfigurator().set_prod()`
whereas your unit-tests should call `TableConfigurator().set_debug()`.

## Using the TableConfigurator

Once configured, the table configurator is often not used directly.
Other classes in the atc framework use it when configured with a resource
ID. You can find examples in the eventhub unittests:
```python
from atc.eh import EventHubCapture
EventHubCapture.from_tc("AtcEh")
```
or in the delta handle unit-tests:
```python
from atc.delta import DeltaHandle
DeltaHandle.from_tc("MyTbl")
```
But sometimes you still need to call the table configurator methods
e.g. when constructing your own sql:
```python
from atc.config_master import TableConfigurator
f"MERGE INTO {TableConfigurator().table_name('MyTbl')} AS target ..."
```

## Further Features

### MNT key
'MNT' is another special replacement, similar to "ID". In production it
is replaced with the string 'mnt' while in debug it is replace with 'tmp'.
The intended usage is in paths where production tables are mounted on
external storage, typically mounted under "/mnt" whereas test tables 
should be written to "/tmp" you can use is as in this example:
```yaml
MyTable:
  name: mydb{ID}.data_table
  path: /{MNT}/somestorage{ENV}/mydb{ID}/data_table
```

### Cross References
In some cases it is useful to refer to other defined resources and their properties.
This is fully supported as shown here:
```yaml
MyDb:
  name: mydb{ID}
  path: /{MNT}/storage{ENV}/mydb{ID}

MyTable:
  name: {MyDb}.mytable
  path: {MyDb_path}/mytable
```
As shown here the "name" property can be accessed with the bare resouce key
whereas other properties can be accessed by appending the property with an 
underscore. (Optionally, appending "_name" is also supported to access the
name, i.e. `{MyDb}` and `{MyDb_name}` are equivalent.)

### Extra details
As already shown in the example above, there is a method to add
further extra details such as an 'ENV' key. Note: The ENV key is not 
a built-in special property. Use the `set_extra` method:
```python
from atc.config_master import TableConfigurator
tc = TableConfigurator()
tc.set_extra(ENV='prod')
```
