### PR TITLE
close sql connection

### DIFF
--- a/src/atc/sql/SqlServer.py
+++ b/src/atc/sql/SqlServer.py
@@ -49,6 +49,7 @@ class SqlServer:
         conn = pyodbc.connect(self.odbc)
         conn.autocommit = True
         conn.execute(sql)
+        conn.close()
 
     def load_sql(self, sql: str):
         self.test_odbc_connection()


### PR DESCRIPTION
When establishing the SQL server connection using pyodbc, the connection should be closed again. Sometimes, when e.g. submitting a test job to a databricks cluster, there is some socket errors. This PR will hopefully accomodate for this. 