### PR TITLE
SqlExecutor

### DIFF
--- a/docs/sql/README.md
+++ b/docs/sql/README.md
@@ -2,10 +2,10 @@
 
 SQL methods ovrview:
 
-* Documentation coming...
-* ...
+* [SQL Server Class](#sql-server-class)
+* [SqlExecutor](#sqlexecutor)
 
-## SQL Class
+## SQL Server Class
 Lets say you have a Azure SQL server called *youservername* with an associated database *yourdatabase*. The username is explicitly defined here as *customusername* and the password as *[REDACTED]*. Variables related to security challenges like passwords are recommended to be located in e.g. [databricks secrets](https://docs.databricks.com/security/secrets/index.html). Here is a usage example:
  
 ```python
@@ -30,4 +30,29 @@ class ExampleSqlServer(SqlServer):
         super().__init__(
             self.hostname, self.database, self.username, self.password, self.port
         )
+```
+
+
+## SqlExecutor
+This nice class can help parse and execute sql-files. It can be used for both executing spark and Azure sql queries.
+
+In the example below the SqlExecutor is inherited, and your sql server is used (see [SQL Server Class](#sql-server-class)). Furthermore, provide the module of the sql-files which can be executed into the *base_module*-variable.  
+ 
+```python
+from atc.sql.SqlExecutor import SqlExecutor
+from tests.cluster.sql import extras
+from tests.cluster.sql.DeliverySqlServer import DeliverySqlServer
+
+class DeliverySqlExecutor(SqlExecutor):
+    def __init__(self):
+        super().__init__(base_module=extras, server=DeliverySqlServer())
+```
+
+In the setup job, one could consider to create all delivery SQL tables:
+
+```python
+# In setup.py
+def setup_production_tables():
+    TableConfigurator().set_prod()
+    DeliverySqlExecutor().execute_sql_file("*")
 ```

--- a/docs/sql/README.md
+++ b/docs/sql/README.md
@@ -36,6 +36,8 @@ class ExampleSqlServer(SqlServer):
 ## SqlExecutor
 This nice class can help parse and execute sql-files. It can be used for both executing spark and Azure sql queries.
 
+*NB: The parser uses the semicolon-character (;) to split the queries. If the character is used for other purposes than closing a query, there might arise some executing issues. Please use the Spark.get().sql() or SqlServer.sql() instead.* 
+
 In the example below the SqlExecutor is inherited, and your sql server is used (see [SQL Server Class](#sql-server-class)). Furthermore, provide the module of the sql-files which can be executed into the *base_module*-variable.  
  
 ```python
@@ -48,11 +50,19 @@ class DeliverySqlExecutor(SqlExecutor):
         super().__init__(base_module=extras, server=DeliverySqlServer())
 ```
 
+If one need to execute sql queries in Databricks using Spark, there is no need for providing a server. By default, the class uses the atc Spark class. 
+```python
+class SparkSqlExecutor(SqlExecutor):
+    def __init__(self):
+        super().__init__(base_module=extras)
+```
+
 In the setup job, one could consider to create all delivery SQL tables:
 
 ```python
 # In setup.py
 def setup_production_tables():
     TableConfigurator().set_prod()
+    SparkSqlExecutor().execute_sql_file("*")
     DeliverySqlExecutor().execute_sql_file("*")
 ```

--- a/src/atc/sql/SqlExecutor.py
+++ b/src/atc/sql/SqlExecutor.py
@@ -11,7 +11,9 @@ from atc.sql.SqlServer import SqlServer
 
 class SqlExecutor:
     def __init__(
-        self, base_module: Union[str, ModuleType] = None, server: SqlServer = None
+        self,
+        base_module: Union[str, ModuleType] = None,
+        server: SqlServer = None,
     ):
         self.base_module = base_module
         self.server = server

--- a/src/atc/sql/SqlExecutor.py
+++ b/src/atc/sql/SqlExecutor.py
@@ -1,0 +1,55 @@
+import re
+from importlib import resources as ir
+from pathlib import Path
+from types import ModuleType
+from typing import Union
+
+from atc.config_master import TableConfigurator
+from atc.spark import Spark
+from atc.sql.SqlServer import SqlServer
+
+
+class SqlExecutor:
+    def __init__(
+        self, base_module: Union[str, ModuleType] = None, server: SqlServer = None
+    ):
+        self.base_module = base_module
+        self.server = server
+
+    def execute_sql_file(self, file_pattern: str):
+        """
+        NB: This sql parser can be challenged in parsing sql statements
+        which do not use semicolon as a query separator only.
+        """
+
+        # prepare file pattern:
+        if file_pattern.endswith(".sql"):
+            file_pattern = file_pattern[:-4]
+
+        file_pattern = file_pattern.replace("*", ".*")
+
+        replacements = TableConfigurator().get_all_details()
+
+        executor = self.server or Spark.get()
+
+        for file_name in ir.contents(self.base_module):
+            extension = Path(file_name).suffix
+            if extension not in [".sql"]:
+                continue
+
+            if not re.match(file_pattern, Path(file_name).stem):
+                continue
+
+            with ir.path(self.base_module, file_name) as file_path:
+                with open(file_path) as file:
+                    conts = file.read()
+                    sql_code = conts.format(**replacements)
+                    for statement in sql_code.split(";"):
+                        cleaned_statement = ""
+                        for line in statement.splitlines(keepends=True):
+                            if line.lstrip().startswith("-- "):
+                                continue
+                            elif line.strip():
+                                cleaned_statement += line
+                        if cleaned_statement:
+                            executor.sql(statement)

--- a/src/atc/sql/SqlServer.py
+++ b/src/atc/sql/SqlServer.py
@@ -51,6 +51,10 @@ class SqlServer:
         conn.execute(sql)
         conn.close()
 
+    # Convenience class for align with Spark.get() method .sql.
+    def sql(self, sql: str):
+        self.execute_sql(sql)
+
     def load_sql(self, sql: str):
         self.test_odbc_connection()
         return Spark.get().read.jdbc(

--- a/tests/cluster/delta/SparkExecutor.py
+++ b/tests/cluster/delta/SparkExecutor.py
@@ -1,0 +1,7 @@
+from atc.sql.SqlExecutor import SqlExecutor
+from tests.cluster.delta import extras
+
+
+class SparkSqlExecutor(SqlExecutor):
+    def __init__(self):
+        super().__init__(base_module=extras)

--- a/tests/cluster/delta/extras/tablenames.yml
+++ b/tests/cluster/delta/extras/tablenames.yml
@@ -1,0 +1,7 @@
+SparkTestDb:
+  name: my_db1{ID}
+  path: /tmp/foo/bar/my_db1/
+
+SparkTestTable1:
+  name: "{SparkTestDb}.tbl1"
+  path: "{SparkTestDb_path}/tbl1"

--- a/tests/cluster/delta/extras/test1.sql
+++ b/tests/cluster/delta/extras/test1.sql
@@ -1,0 +1,8 @@
+CREATE DATABASE IF NOT EXISTS "{SparkTestDb}"
+LOCATION "{SparkTestDb}";
+
+CREATE TABLE IF NOT EXISTS "{SparkTestTable1}"(
+a int,
+)
+USING DELTA
+LOCATION "{SparkTestTable1_path}"

--- a/tests/cluster/delta/extras/test1.sql
+++ b/tests/cluster/delta/extras/test1.sql
@@ -1,8 +1,8 @@
-CREATE DATABASE IF NOT EXISTS "{SparkTestDb}"
-LOCATION "{SparkTestDb}";
+CREATE DATABASE IF NOT EXISTS {SparkTestDb}
+LOCATION "{SparkTestDb_path}";
 
-CREATE TABLE IF NOT EXISTS "{SparkTestTable1}"(
-a int,
+CREATE TABLE IF NOT EXISTS {SparkTestTable1}(
+a int
 )
 USING DELTA
 LOCATION "{SparkTestTable1_path}"

--- a/tests/cluster/delta/test_sparkexecutor.py
+++ b/tests/cluster/delta/test_sparkexecutor.py
@@ -23,13 +23,13 @@ class DeliverySparkExecutorTests(unittest.TestCase):
         cls.dh = DeltaHandle
 
         # Ensure no table is there
-        cls.dbh.from_tc("SparkTestDb").drop()
+        cls.dbh.from_tc("SparkTestDb").drop_cascade()
 
         cls.dh.from_tc("SparkTestTable1").drop()
 
     @classmethod
     def tearDownClass(cls):
-        cls.dbh.from_tc("SparkTestDb").drop()
+        cls.dbh.from_tc("SparkTestDb").drop_cascade()
         cls.dh.from_tc("SparkTestTable1").drop()
 
     def test_can_execute(self):

--- a/tests/cluster/delta/test_sparkexecutor.py
+++ b/tests/cluster/delta/test_sparkexecutor.py
@@ -1,0 +1,39 @@
+import unittest
+
+from atc.config_master import TableConfigurator
+from atc.delta import DbHandle, DeltaHandle
+from tests.cluster.delta import extras
+from tests.cluster.delta.SparkExecutor import SparkSqlExecutor
+
+
+class DeliverySparkExecutorTests(unittest.TestCase):
+    dh = None
+    tc = None
+    dbh = None
+
+    @classmethod
+    def setUpClass(cls):
+
+        # Register the delivery table for the table configurator
+        cls.tc = TableConfigurator()
+        cls.tc.add_resource_path(extras)
+        cls.tc.set_debug()
+
+        cls.dbh = DbHandle
+        cls.dh = DeltaHandle
+
+        # Ensure no table is there
+        cls.dbh.from_tc("SparkTestDb").drop()
+        cls.dh.from_tc("SparkTestTable1").drop_table()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.dbh.from_tc("SparkTestDb").drop()
+        cls.dh.from_tc("SparkTestTable1").drop_table()
+
+    def test_can_execute(self):
+        SparkSqlExecutor().execute_sql_file("test1")
+
+        self.dh.from_tc("SparkTestTable1").read()
+
+        self.assertTrue(True)

--- a/tests/cluster/delta/test_sparkexecutor.py
+++ b/tests/cluster/delta/test_sparkexecutor.py
@@ -24,12 +24,13 @@ class DeliverySparkExecutorTests(unittest.TestCase):
 
         # Ensure no table is there
         cls.dbh.from_tc("SparkTestDb").drop()
-        cls.dh.from_tc("SparkTestTable1").drop_table()
+
+        cls.dh.from_tc("SparkTestTable1").drop()
 
     @classmethod
     def tearDownClass(cls):
         cls.dbh.from_tc("SparkTestDb").drop()
-        cls.dh.from_tc("SparkTestTable1").drop_table()
+        cls.dh.from_tc("SparkTestTable1").drop()
 
     def test_can_execute(self):
         SparkSqlExecutor().execute_sql_file("test1")

--- a/tests/cluster/sql/DeliverySqlExecutor.py
+++ b/tests/cluster/sql/DeliverySqlExecutor.py
@@ -1,0 +1,8 @@
+from atc.sql.SqlExecutor import SqlExecutor
+from tests.cluster.sql import extras
+from tests.cluster.sql.DeliverySqlServer import DeliverySqlServer
+
+
+class DeliverySqlExecutor(SqlExecutor):
+    def __init__(self):
+        super().__init__(base_module=extras, server=DeliverySqlServer())

--- a/tests/cluster/sql/extras/test1.sql
+++ b/tests/cluster/sql/extras/test1.sql
@@ -1,7 +1,7 @@
 CREATE TABLE {SqlTestTable1}
 (
  testcolumn INT NULL
-)
+);
 
 -- COMMAND ----------
 

--- a/tests/cluster/sql/test_deliveryexecutor.py
+++ b/tests/cluster/sql/test_deliveryexecutor.py
@@ -20,9 +20,14 @@ class DeliverySqlExecutorTests(unittest.TestCase):
         cls.tc.add_resource_path(extras)
         cls.tc.set_debug()
 
+        # Ensure no table is there
+        cls.sql_server.drop_table("SqlTestTable1")
+        cls.sql_server.drop_table("SqlTestTable2")
+
     @classmethod
     def tearDownClass(cls):
         cls.sql_server.drop_table("SqlTestTable1")
+        cls.sql_server.drop_table("SqlTestTable2")
 
     def test_can_execute(self):
         DeliverySqlExecutor().execute_sql_file("test1")

--- a/tests/cluster/sql/test_deliveryexecutor.py
+++ b/tests/cluster/sql/test_deliveryexecutor.py
@@ -1,0 +1,25 @@
+import unittest
+
+from tests.cluster.sql.DeliverySqlExecutor import DeliverySqlExecutor
+from tests.cluster.sql.DeliverySqlServer import DeliverySqlServer
+
+
+class DeliverySqlExecutorTests(unittest.TestCase):
+    sql_server = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.sql_server = DeliverySqlServer()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.sql_server.drop_table("SqlTestTable1")
+
+    def test_can_execute(self):
+        DeliverySqlExecutor().execute_sql_file("test1")
+
+        self.sql_server.read_table("SqlTestTable1")
+
+        self.sql_server.read_table("SqlTestTable2")
+
+        self.assertTrue(True)

--- a/tests/cluster/sql/test_deliveryexecutor.py
+++ b/tests/cluster/sql/test_deliveryexecutor.py
@@ -1,15 +1,24 @@
 import unittest
 
+from atc.config_master import TableConfigurator
 from tests.cluster.sql.DeliverySqlExecutor import DeliverySqlExecutor
 from tests.cluster.sql.DeliverySqlServer import DeliverySqlServer
 
+from . import extras
+
 
 class DeliverySqlExecutorTests(unittest.TestCase):
+    tc = None
     sql_server = None
 
     @classmethod
     def setUpClass(cls):
         cls.sql_server = DeliverySqlServer()
+
+        # Register the delivery table for the table configurator
+        cls.tc = TableConfigurator()
+        cls.tc.add_resource_path(extras)
+        cls.tc.set_debug()
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
This PR implement a SqlExecutor.

The class can take .sql files, and parse them to either spark or sqlserver.

The method could for example be used when setting up the whole dataplatform. Then the sql server tables and the spark tables can be created at setup. 