### PR TITLE
create drop oldest duplicate incl test

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Check code linting
         run: flake8 .
       - name: Install the package
-        run: python setup.py develop
+        run: pip install .
       - name: Run Tests
         run: python -m pytest tests/local
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -5,3 +5,4 @@ black
 isort
 flake8
 dbx
+atc-dataplatform-tools

--- a/docs/transformations/README.md
+++ b/docs/transformations/README.md
@@ -5,6 +5,7 @@ Transformations in atc-dataplatform:
 * [Concatenate dataframes](#concatenate-data-frames)
 * [Fuzzy select](#fuzzy-select-transformer)
 * [Merge df into target](#merge-df-into-target)
+* [DropOldestDuplicates](#dropoldestduplicates)
 
 ## Concatenate data frames
 
@@ -204,3 +205,41 @@ select * from test.testTarget order by Id
 
 As one can see, the row with id=2 is now merged such that the model went from "Les Paul" to "Starfire". 
 The two other rows where inserted. 
+
+## DropOldestDuplicates
+
+This transformation helps dropping duplicates based on time. If there is multiple duplicates, 
+only the newest row remain. In the example below, a dataframe has several duplicates - since a unique record is 
+defined by a combination of a guitar-id, model and brand. As times go by the amount
+of guitars available in a store changes. Lets assume that we only want the newest record
+and dropping the oldest duplicates:
+
+``` python 
+from atc.utils.DropOldestDuplicates import DropOldestDuplicates
+data =
+
+| id| model|     brand|amount|         timecolumn|
++---+------+----------+------+-------------------+
+|  1|Fender|Telecaster|     5|2021-07-01 10:00:00|
+|  1|Fender|Telecaster|     4|2021-07-01 11:00:00|
+|  2|Gibson|  Les Paul|    27|2021-07-01 11:00:00|
+|  3|Ibanez|        RG|    22|2021-08-01 11:00:00|
+|  3|Ibanez|        RG|    26|2021-09-01 11:00:00|
+|  3|Ibanez|        RG|    18|2021-10-01 11:00:00|
++---+------+----------+------+-------------------+
+
+df = DropOldestDuplicatesTransformer( 
+            cols=["id", "model", "brand"], 
+            orderByColumn="timecolumn"
+            ).process(data)
+df.show()
+
+| id| model|     brand|amount|         timecolumn|
++---+------+----------+------+-------------------+
+|  1|Fender|Telecaster|     4|2021-07-01 11:00:00|
+|  2|Gibson|  Les Paul|    27|2021-07-01 11:00:00|
+|  3|Ibanez|        RG|    18|2021-10-01 11:00:00|
++---+------+----------+------+-------------------+
+```
+
+Notice, the oldest duplicates are dropped. 

--- a/src/atc/transformers/__init__.py
+++ b/src/atc/transformers/__init__.py
@@ -1,2 +1,5 @@
+from .drop_oldest_duplicate_transformer import (  # noqa: F401
+    DropOldestDuplicatesTransformer,
+)
 from .simple_sql_transformer import SimpleSqlServerTransformer  # noqa: F401
 from .union_transformer import UnionTransformer  # noqa: F401

--- a/src/atc/transformers/drop_oldest_duplicate_transformer.py
+++ b/src/atc/transformers/drop_oldest_duplicate_transformer.py
@@ -1,0 +1,19 @@
+from typing import List
+
+from pyspark.sql import DataFrame
+
+from atc.etl import Transformer
+from atc.utils import DropOldestDuplicates
+
+
+class DropOldestDuplicatesTransformer(Transformer):
+    def __init__(self, *, cols: List[str], orderByColumn: str):
+        super().__init__()
+        self.cols = cols
+        self.orderByColumn = orderByColumn
+
+    def process(self, df: DataFrame) -> DataFrame:
+
+        return DropOldestDuplicates(
+            df=df, cols=self.cols, orderByColumn=self.orderByColumn
+        )

--- a/src/atc/utils/DropOldestDuplicates.py
+++ b/src/atc/utils/DropOldestDuplicates.py
@@ -1,0 +1,26 @@
+from typing import List
+
+import pyspark.sql.functions as f
+from pyspark.sql import DataFrame
+from pyspark.sql.window import Window
+
+
+def DropOldestDuplicates(
+    *, df: DataFrame, cols: List[str], orderByColumn: str
+) -> DataFrame:
+    """
+    Removes the oldest duplicates.
+
+    In other words, if there is multiple duplicates, only the newest row remain.
+
+    param df: The pyspark DataFrame with potential duplicates
+    param cols: A list of column names that the window function is partitioned by
+    param orderByColumn: The time formatted column to order by
+
+    return: DataFrame with oldest duplicate rows removed
+
+    """
+    wnd = Window.partitionBy(cols).orderBy(df[orderByColumn].desc())
+    df = df.withColumn("rowNum", f.row_number().over(wnd)).where(f.col("rowNum") == 1)
+    df = df.drop("rowNum")
+    return df

--- a/src/atc/utils/__init__.py
+++ b/src/atc/utils/__init__.py
@@ -1,5 +1,6 @@
 from .DataframeCreator import DataframeCreator
+from .DropOldestDuplicates import DropOldestDuplicates
 from .MockExtractor import MockExtractor
 from .MockLoader import MockLoader
 
-__all__ = [DataframeCreator, MockLoader, MockExtractor]
+__all__ = [DataframeCreator, MockLoader, MockExtractor, DropOldestDuplicates]

--- a/tests/cluster/transformations/test_dropoldestduplicates.py
+++ b/tests/cluster/transformations/test_dropoldestduplicates.py
@@ -15,8 +15,8 @@ from atc.transformers.drop_oldest_duplicate_transformer import (
 from atc.utils import DropOldestDuplicates
 
 
-class TestDropOldestDuplicates(DataframeTestCase):
-    def test_drop_oldest_duplicates(self):
+class TestDropOldestDuplicatesTransformer(DataframeTestCase):
+    def test_drop_oldest_duplicates_transformer(self):
         data = [
             (1, "Fender", "Telecaster", 5, dt_utc(2021, 7, 1, 10)),
             (1, "Fender", "Telecaster", 4, dt_utc(2021, 7, 1, 11)),
@@ -42,15 +42,16 @@ class TestDropOldestDuplicates(DataframeTestCase):
             ]
         )
 
-        df = Spark.get().createDataFrame(data=data, schema=schema)
-
-        # Testing the function
-        df = DropOldestDuplicates(
-            df=df, cols=["id", "model", "brand"], orderByColumn="timecolumn"
-        ).orderBy("id")
+        df2 = (
+            DropOldestDuplicatesTransformer(
+                cols=["id", "model", "brand"], orderByColumn="timecolumn"
+            )
+            .process(data)
+            .orderBy("id")
+        )
 
         self.assertDataframeMatches(
-            df,
+            df2,
             None,
             expected_data=expected_data,
         )

--- a/tests/cluster/transformations/test_dropoldestduplicates.py
+++ b/tests/cluster/transformations/test_dropoldestduplicates.py
@@ -12,7 +12,6 @@ from atc.spark import Spark
 from atc.transformers.drop_oldest_duplicate_transformer import (
     DropOldestDuplicatesTransformer,
 )
-from atc.utils import DropOldestDuplicates
 
 
 class TestDropOldestDuplicatesTransformer(DataframeTestCase):
@@ -42,11 +41,13 @@ class TestDropOldestDuplicatesTransformer(DataframeTestCase):
             ]
         )
 
+        df = Spark.get().createDataFrame(data=data, schema=schema)
+
         df2 = (
             DropOldestDuplicatesTransformer(
                 cols=["id", "model", "brand"], orderByColumn="timecolumn"
             )
-            .process(data)
+            .process(df)
             .orderBy("id")
         )
 

--- a/tests/local/utils/test_dropoldestduplicates.py
+++ b/tests/local/utils/test_dropoldestduplicates.py
@@ -9,7 +9,7 @@ from pyspark.sql.types import (
 )
 
 from atc.spark import Spark
-from atc.utils.DropOldestDuplicates import DropOldestDuplicates
+from atc.utils import DropOldestDuplicates
 
 
 class TestDropOldestDuplicates(DataframeTestCase):

--- a/tests/local/utils/test_dropoldestduplicates.py
+++ b/tests/local/utils/test_dropoldestduplicates.py
@@ -1,0 +1,71 @@
+from atc_tools.testing import DataframeTestCase
+from atc_tools.time import dt_utc
+from pyspark.sql.types import (
+    IntegerType,
+    StringType,
+    StructField,
+    StructType,
+    TimestampType,
+)
+
+from atc.spark import Spark
+from atc.transformers.drop_oldest_duplicate_transformer import (
+    DropOldestDuplicatesTransformer,
+)
+from atc.utils import DropOldestDuplicates
+
+
+class TestDropOldestDuplicates(DataframeTestCase):
+    def test_drop_oldest_duplicates(self):
+        data = [
+            (1, "Fender", "Telecaster", 5, dt_utc(2021, 7, 1, 10)),
+            (1, "Fender", "Telecaster", 4, dt_utc(2021, 7, 1, 11)),
+            (2, "Gibson", "Les Paul", 27, dt_utc(2021, 7, 1, 11)),
+            (3, "Ibanez", "RG", 22, dt_utc(2021, 8, 1, 11)),
+            (3, "Ibanez", "RG", 26, dt_utc(2021, 9, 1, 11)),
+            (3, "Ibanez", "RG", 18, dt_utc(2021, 10, 1, 11)),
+        ]
+
+        expected_data = [
+            [1, "Fender", "Telecaster", 4, dt_utc(2021, 7, 1, 11)],
+            [2, "Gibson", "Les Paul", 27, dt_utc(2021, 7, 1, 11)],
+            [3, "Ibanez", "RG", 18, dt_utc(2021, 10, 1, 11)],
+        ]
+
+        schema = StructType(
+            [
+                StructField("id", IntegerType(), True),
+                StructField("model", StringType(), True),
+                StructField("brand", StringType(), True),
+                StructField("amount", IntegerType(), True),
+                StructField("timecolumn", TimestampType(), True),
+            ]
+        )
+
+        df = Spark.get().createDataFrame(data=data, schema=schema)
+
+        # Testing the function
+        df1 = DropOldestDuplicates(
+            df=df, cols=["id", "model", "brand"], orderByColumn="timecolumn"
+        ).orderBy("id")
+
+        self.assertDataframeMatches(
+            df1,
+            None,
+            expected_data=expected_data,
+        )
+
+        # Testing ETL transformer
+        df2 = (
+            DropOldestDuplicatesTransformer(
+                cols=["id", "model", "brand"], orderByColumn="timecolumn"
+            )
+            .process(df)
+            .orderBy("id")
+        )
+
+        self.assertDataframeMatches(
+            df2,
+            None,
+            expected_data=expected_data,
+        )

--- a/tests/local/utils/test_dropoldestduplicates.py
+++ b/tests/local/utils/test_dropoldestduplicates.py
@@ -9,10 +9,7 @@ from pyspark.sql.types import (
 )
 
 from atc.spark import Spark
-from atc.transformers.drop_oldest_duplicate_transformer import (
-    DropOldestDuplicatesTransformer,
-)
-from atc.utils import DropOldestDuplicates
+from atc.utils.DropOldestDuplicates import DropOldestDuplicates
 
 
 class TestDropOldestDuplicates(DataframeTestCase):


### PR DESCRIPTION
This transformer does almost the same as dropDuplicates. But, drop duplicates does not neccesarily drops the same rows each time. This transformer drops the oldest duplicates from a dataframe. 