### PR TITLE
Feature/extended transformer 2.0

### DIFF
--- a/docs/etl/README.md
+++ b/docs/etl/README.md
@@ -606,7 +606,7 @@ class NoopLoader(Loader):
         df.show()
 
 
-print("ETL Orchestrator using composit innter orchestrator")
+print("ETL Orchestrator using composit inner orchestrator")
 etl_inner = (
     Orchestrator()
     .transform_with(CountryOfOriginTransformer())

--- a/docs/etl/README.md
+++ b/docs/etl/README.md
@@ -38,13 +38,17 @@ from atc.etl import Extractor, Transformer, Loader, Orchestrator
 
 ### Principles
 
-All ETL classes, **Orchestrator**, **Extractor**, **Transformer** and **Loader** are ETL objects.
+All ETL classes, **Orchestrator**, **Extractor**, **Transformer**, **Loader**, **ExtendedTransformer**, and **ExtendedLoader** are ETL objects.
 This means that they have a method `etl(self, inputs: dataset_group) -> dataset_group`
 (where `dataset_group = Dict[str, DataFrame]`) that transforms a set of import to a set of 
 outputs. The special properties of each type are
- - **Extractor** always adds its result to the total set,
- - **Transformer** consumes all inputs and adds a single result dataframe,
- - **Loader** acts as a sink, while passing its input on to the next sink,
+ - **Extractor** always adds its result to the total set
+ - **Transformer** consumes all inputs and adds a single result dataframe
+ - **Loader** acts as a sink, while passing its input on to the next sink
+ - **ExtendedTransformer** does not consume the input(s) and adds a single result dataframe
+ - **ExtendedLoader** same behaviour as the **Loader**, but in addition it handles dataset input key(s)
+
+The usecase for the **ExtendedTransformer** and the **ExtendedLoader** comes when there is a need to keep previously extracted (or transformed) dataframes after a transformation step. When working with these classes it is crucial to set dataset input keys and dataset output keys. This ensures that the transformer and/or loader has explicit information on which dataframe(s) to handle.
 
 The special case of the  **Orchestrator** is that it takes all its steps and executes them
 in sequence on its inputs. Running in the default `execute()` method, the inputs are empty,
@@ -621,5 +625,110 @@ etl_outer = (
 )
 
 etl_outer.execute()
+
+```
+
+### Example-8
+
+This example illustrates the use of `ExtendedTransformer` and `ExtendedLoader`.  
+The job here is to join the two extracted dataframes - an employees dataframe and a birthdays dataframe.  
+But, before the birthdays can be join onto the employees, the employees dataframe require a transformation step.  
+As the transformation step of employees is handled by an `ExtendedTransformer`, it does not consume the other inputs from the `dataset_group`.  
+Hence, birthdays is still available from the inputs - even after the transformation of employees.  
+Then both frames can be joined and the final dataframe saved via an `ExtendedLoader`.   
+When working with `ExtendedTransformer` and `ExtendedLoader` it is important to mind that dataset keys are crucial.  
+Setting both input and output dataset key(s) ensure that the `ExtendedTransformers` and `ExtendedLoaders` handle the intended dataframes.
+```python
+import pyspark.sql.functions as f
+from pyspark.sql import DataFrame
+from pyspark.sql.types import IntegerType, StringType, StructField, StructType
+
+from atc.etl import ExtendedLoader, ExtendedTransformer, Extractor, Orchestrator
+from atc.etl.types import dataset_group
+from atc.spark import Spark
+
+
+class OfficeEmployeeExtractor(Extractor):
+    def read(self) -> DataFrame:
+        return Spark.get().createDataFrame(
+            Spark.get().sparkContext.parallelize(
+                [
+                    ("1", "Michael Scott", "Regional Manager"),
+                    ("2", "Dwight K. Schrute", "Assistant to the Regional Manager"),
+                    ("3", "Jim Halpert", "Salesman"),
+                    ("4", "Pam Beesly", "Receptionist"),
+                ]
+            ),
+            StructType(
+                [
+                    StructField("id", StringType()),
+                    StructField("name", StringType()),
+                    StructField("position", StringType()),
+                ]
+            ),
+        )
+
+
+class OfficeBirthdaysExtractor(Extractor):
+    def read(self) -> DataFrame:
+        return Spark.get().createDataFrame(
+            Spark.get().sparkContext.parallelize(
+                [
+                    (1, "March 15"),
+                    (2, "January 20"),
+                    (3, "October 1"),
+                    (4, "March 25"),
+                ]
+            ),
+            StructType(
+                [
+                    StructField("id", IntegerType()),
+                    StructField("birthday", StringType()),
+                ]
+            ),
+        )
+
+
+class IntegerTransformer(ExtendedTransformer):
+    def process(self, df: DataFrame) -> DataFrame:
+        return df.withColumn("id", f.col("id").cast(IntegerType()))
+
+
+class JoinTransformer(ExtendedTransformer):
+    def process_many(self, dataset: dataset_group) -> DataFrame:
+
+        df_employee = dataset["df_employee_transformed"]
+        df_birthdays = dataset["df_birthdays"]
+
+        return df_employee.join(other=df_birthdays, on="id")
+
+
+class ExtendedNoopLoader(ExtendedLoader):
+    def save(self, df: DataFrame) -> None:
+        df.write.format("noop").mode("overwrite").save()
+        df.printSchema()
+        df.show()
+
+
+print("ETL Orchestrator using two extended transformers")
+etl = (
+    Orchestrator()
+    .extract_from(OfficeEmployeeExtractor(dataset_key="df_employee"))
+    .extract_from(OfficeBirthdaysExtractor(dataset_key="df_birthdays"))
+    .transform_with(
+        IntegerTransformer(
+            dataset_input_key="df_employee",
+            dataset_output_key="df_employee_transformed",
+        )
+    )
+    .transform_with(
+        JoinTransformer(
+            dataset_input_key_list=["df_employee_transformed", "df_birthdays"],
+            dataset_output_key="df_final",
+        )
+    )
+    .load_into(ExtendedNoopLoader(dataset_input_key="df_final"))
+)
+etl.execute()
 
 ```

--- a/examples/etl/composit_orchestration_example.py
+++ b/examples/etl/composit_orchestration_example.py
@@ -71,7 +71,7 @@ class NoopLoader(Loader):
         df.show()
 
 
-print("ETL Orchestrator using composit innter orchestrator")
+print("ETL Orchestrator using composit inner orchestrator")
 etl_inner = (
     Orchestrator().transform_with(CountryOfOriginTransformer()).load_into(NoopLoader())
 )

--- a/examples/etl/extended_etl_example.py
+++ b/examples/etl/extended_etl_example.py
@@ -1,0 +1,91 @@
+import pyspark.sql.functions as f
+from pyspark.sql import DataFrame
+from pyspark.sql.types import IntegerType, StringType, StructField, StructType
+
+from atc.etl import ExtendedLoader, ExtendedTransformer, Extractor, Orchestrator
+from atc.etl.types import dataset_group
+from atc.spark import Spark
+
+
+class OfficeEmployeeExtractor(Extractor):
+    def read(self) -> DataFrame:
+        return Spark.get().createDataFrame(
+            Spark.get().sparkContext.parallelize(
+                [
+                    ("1", "Michael Scott", "Regional Manager"),
+                    ("2", "Dwight K. Schrute", "Assistant to the Regional Manager"),
+                    ("3", "Jim Halpert", "Salesman"),
+                    ("4", "Pam Beesly", "Receptionist"),
+                ]
+            ),
+            StructType(
+                [
+                    StructField("id", StringType()),
+                    StructField("name", StringType()),
+                    StructField("position", StringType()),
+                ]
+            ),
+        )
+
+
+class OfficeBirthdaysExtractor(Extractor):
+    def read(self) -> DataFrame:
+        return Spark.get().createDataFrame(
+            Spark.get().sparkContext.parallelize(
+                [
+                    (1, "March 15"),
+                    (2, "January 20"),
+                    (3, "October 1"),
+                    (4, "March 25"),
+                ]
+            ),
+            StructType(
+                [
+                    StructField("id", IntegerType()),
+                    StructField("birthday", StringType()),
+                ]
+            ),
+        )
+
+
+class IntegerTransformer(ExtendedTransformer):
+    def process(self, df: DataFrame) -> DataFrame:
+        return df.withColumn("id", f.col("id").cast(IntegerType()))
+
+
+class JoinTransformer(ExtendedTransformer):
+    def process_many(self, dataset: dataset_group) -> DataFrame:
+
+        df_employee = dataset["df_employee_transformed"]
+        df_birthdays = dataset["df_birthdays"]
+
+        return df_employee.join(other=df_birthdays, on="id")
+
+
+class ExtendedNoopLoader(ExtendedLoader):
+    def save(self, df: DataFrame) -> None:
+        df.write.format("noop").mode("overwrite").save()
+        df.printSchema()
+        df.show()
+
+
+print("ETL Orchestrator using two extended transformers")
+etl = (
+    Orchestrator()
+    .extract_from(OfficeEmployeeExtractor(dataset_key="df_employee"))
+    .extract_from(OfficeBirthdaysExtractor(dataset_key="df_birthdays"))
+    .transform_with(
+        IntegerTransformer(
+            dataset_input_key="df_employee",
+            dataset_output_key="df_employee_transformed",
+        )
+    )
+    .transform_with(
+        JoinTransformer(
+            dataset_input_key_list=["df_employee_transformed", "df_birthdays"],
+            dataset_output_key="df_final",
+        )
+    )
+    .load_into(ExtendedNoopLoader(dataset_input_key="df_final"))
+)
+etl.execute()

--- a/src/atc/etl/__init__.py
+++ b/src/atc/etl/__init__.py
@@ -1,3 +1,4 @@
+from .extended_loader import ExtendedLoader
 from .extended_transformer import ExtendedTransformer
 from .extractor import Extractor
 from .loader import Loader
@@ -12,5 +13,6 @@ __all__ = [
     "Orchestrator",
     "EtlBase",
     "ExtendedTransformer",
+    "ExtendedLoader",
     "dataset_group",
 ]

--- a/src/atc/etl/__init__.py
+++ b/src/atc/etl/__init__.py
@@ -1,3 +1,4 @@
+from .extended_transformer import ExtendedTransformer
 from .extractor import Extractor
 from .loader import Loader
 from .orchestrator import Orchestrator
@@ -10,5 +11,6 @@ __all__ = [
     "Transformer",
     "Orchestrator",
     "EtlBase",
+    "ExtendedTransformer",
     "dataset_group",
 ]

--- a/src/atc/etl/extended_loader.py
+++ b/src/atc/etl/extended_loader.py
@@ -1,0 +1,46 @@
+from typing import List
+
+from pyspark.sql import DataFrame
+
+from .types import EtlBase, dataset_group
+
+
+class ExtendedLoader(EtlBase):
+    """
+    An ExtendedLoader is a data sink, which is indicated by the fact that
+    the save method has no return.
+
+    In regards to the etl step, an ExtendedLoader USES the input dataset(s)
+    and does not consume or change it.
+    """
+
+    def __init__(
+        self, dataset_input_key: str = None, dataset_input_key_list: List[str] = None
+    ):
+        self.dataset_input_key = dataset_input_key
+        self.dataset_input_key_list = dataset_input_key_list
+
+    def etl(self, inputs: dataset_group) -> dataset_group:
+
+        if self.dataset_input_key:
+            self.save(inputs[self.dataset_input_key])
+        elif self.dataset_input_key_list:
+            self.save_many(
+                {
+                    datasetKey: df
+                    for datasetKey, df in inputs.items()
+                    if datasetKey in self.dataset_input_key_list
+                }
+            )
+        elif len(inputs) == 1:
+            self.save(next(iter(inputs.values())))
+        else:
+            self.save_many(inputs)
+
+        return inputs
+
+    def save(self, df: DataFrame) -> None:
+        raise NotImplementedError()
+
+    def save_many(self, datasets: dataset_group) -> None:
+        raise NotImplementedError()

--- a/src/atc/etl/extended_transformer.py
+++ b/src/atc/etl/extended_transformer.py
@@ -1,0 +1,58 @@
+from abc import abstractmethod
+from typing import List
+
+from pyspark.sql import DataFrame
+
+from atc.etl.types import EtlBase, dataset_group
+
+
+class ExtendedTransformer(EtlBase):
+    """If you only want to transform a single input dataframe,
+    implement `process`
+    if you want to transform a set of dataframes,
+    implement `process_many`
+
+    In regards to the etl step, the ExtendedTransformer does NOT CONSUME the inputs
+    and APPENDs the result of its transformation stage to the list of inputs.
+    """
+
+    def __init__(
+        self,
+        *,
+        dataset_output_key: str = None,
+        dataset_input_key: str = None,
+        dataset_input_key_list: List[str] = None,
+    ):
+        if dataset_output_key is None:
+            dataset_output_key = type(self).__name__
+        self.dataset_output_key = dataset_output_key
+        self.dataset_input_key = dataset_input_key
+        self.dataset_input_key_list = dataset_input_key_list
+
+    def etl(self, inputs: dataset_group) -> dataset_group:
+
+        if self.dataset_input_key:
+            df = self.process(inputs[self.dataset_input_key])
+        elif self.dataset_input_key_list:
+            df = self.process_many(
+                {
+                    datasetKey: df
+                    for datasetKey, df in inputs.items()
+                    if datasetKey in self.dataset_input_key_list
+                }
+            )
+        elif len(inputs) == 1:
+            df = self.process(next(iter(inputs.values())))
+        else:
+            df = self.process_many(inputs)
+
+        inputs[self.dataset_output_key] = df
+        return inputs
+
+    @abstractmethod
+    def process(self, df: DataFrame) -> DataFrame:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def process_many(self, datasets: dataset_group) -> DataFrame:
+        raise NotImplementedError()

--- a/tests/cluster/etl/test_extended_loader.py
+++ b/tests/cluster/etl/test_extended_loader.py
@@ -1,0 +1,98 @@
+import unittest
+from unittest.mock import MagicMock
+
+from pyspark.sql.types import IntegerType, StringType, StructField, StructType
+
+from atc.etl import ExtendedLoader
+from atc.spark import Spark
+
+
+class LoaderTests(unittest.TestCase):
+    def setUp(self):
+
+        self.loader = ExtendedLoader()
+        self.loader.save = MagicMock()
+        self.loader.save_many = MagicMock()
+
+        self.loader_input_key = ExtendedLoader(dataset_input_key="my_input_key")
+        self.loader_input_key.save = MagicMock()
+        self.loader_input_key.save_many = MagicMock()
+
+        self.dataset_input_key_list = ["my_input_key_1", "my_input_key_2"]
+        self.loader_input_key_list = ExtendedLoader(
+            dataset_input_key_list=self.dataset_input_key_list
+        )
+        self.loader_input_key_list.save = MagicMock()
+        self.loader_input_key_list.save_many = MagicMock()
+
+        self.df = create_dataframe()
+        self.df_empty = create_empty_dataframe()
+
+    def test_return_inputs(self):
+        # loader returns ouput
+        input = {"df": self.df}
+        result = self.loader.etl(input)
+        self.assertIs(input, result)
+
+    def test_save(self):
+        # save is called when:
+        # - inputs has one df
+        # - dataset_input_key is not given
+        self.loader.etl({"df": self.df})
+        self.assertTrue(self.loader.save.called)
+        self.assertFalse(self.loader.save_many.called)
+
+    def test_save_many(self):
+        # save_many is called when:
+        # - inputs has more than one df
+        # - dataset_input_key is not given
+        self.loader.etl({"df1": self.df, "df2": self.df})
+        self.assertFalse(self.loader.save.called)
+        self.assertTrue(self.loader.save_many.called)
+
+    def test_save_input_key(self):
+        # save is called when:
+        # - inputs has more than one df
+        # - dataset_input_key is given
+        self.loader_input_key.etl({"df": self.df_empty, "my_input_key": self.df})
+        self.assertTrue(self.loader_input_key.save.called)
+        self.assertFalse(self.loader_input_key.save_many.called)
+        self.assertIs(self.loader_input_key.save.call_args[0][0], self.df)
+
+    def test_save_many_input_key_list(self):
+        # save_many is called when:
+        # - inputs has more than one df
+        # - dataset_input_key_list is given
+        self.loader_input_key_list.etl(
+            {"df": self.df_empty, "my_input_key_1": self.df, "my_input_key_2": self.df}
+        )
+        self.assertFalse(self.loader_input_key_list.save.called)
+        self.assertTrue(self.loader_input_key_list.save_many.called)
+
+        for input_key in self.dataset_input_key_list:
+            self.assertTrue(
+                input_key
+                in dict(self.loader_input_key_list.save_many.call_args[0][0]).keys()
+            )
+
+
+def create_dataframe():
+    data = [(1, "1"), (2, "2"), (3, "3")]
+
+    schema = StructType(
+        [
+            StructField("id", IntegerType(), False),
+            StructField("text", StringType(), False),
+        ]
+    )
+
+    return Spark.get().createDataFrame(data=data, schema=schema)
+
+
+def create_empty_dataframe():
+    data = [()]
+    return Spark.get().createDataFrame(data=data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cluster/etl/test_extended_transformer.py
+++ b/tests/cluster/etl/test_extended_transformer.py
@@ -1,0 +1,112 @@
+import unittest
+
+from pyspark.sql import DataFrame
+from pyspark.sql.types import IntegerType, StringType, StructField, StructType
+
+from atc.etl import ExtendedTransformer
+from atc.etl.types import dataset_group
+from atc.spark import Spark
+
+
+class TransformerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+
+        cls.transformer = TestTransformer()
+        cls.df = create_dataframe()
+
+        cls.transformer_output_key = TestTransformer(dataset_output_key="my_output_key")
+        cls.transformer_input_key = TestTransformer(dataset_input_key="my_input_key")
+        cls.transformer_input_key_list = TestTransformer(
+            dataset_input_key_list=["my_input_key_1", "my_input_key_2"]
+        )
+
+    def test_process(self):
+        # process is called when:
+        # - inputs has one df
+        # - dataset_input_key is not given
+        result = self.transformer.etl({"df": self.df})
+        self.assertIs(self.df, list(result.values())[1])
+
+    def test_process_many(self):
+        # process_many is called when:
+        # - inputs has more than one df
+        # - dataset_input_key is not given
+        result = self.transformer.etl({"df1": self.df, "df2": self.df})
+        self.assertEqual(6, list(result.values())[2].count())
+
+    def test_process_no_key(self):
+        # process sets dataset_ouput_key equivalent to the transformer class when:
+        # - dataset_output_key is not given
+        result = self.transformer.etl({"df": self.df})
+        self.assertEqual("TestTransformer", list(result.keys())[1])
+
+    def test_process_many_no_key(self):
+        # process_many sets dataset_ouput_key equivalent to the transformer class when:
+        # - dataset_output_key is not given
+        result = self.transformer.etl({"df1": self.df, "df2": self.df})
+        self.assertEqual("TestTransformer", list(result.keys())[2])
+
+    def test_process_output_key(self):
+        # process sets dataset_output_key equiavalent to the input when:
+        # - dataset_output_key is given
+        result = self.transformer_output_key.etl({"df": self.df})
+        self.assertEqual("my_output_key", list(result.keys())[1])
+
+    def test_process_many_output_key(self):
+        # process_many sets dataset_output_key equiavalent to the input when:
+        # - dataset_output_key is given
+        result = self.transformer_output_key.etl({"df1": self.df, "df2": self.df})
+        self.assertEqual("my_output_key", list(result.keys())[2])
+
+    def test_process_input_key(self):
+        # process is called when:
+        # - dataset_input_key is given
+        result = self.transformer_input_key.etl({"my_input_key": self.df})
+        self.assertIs(self.df, list(result.values())[1])
+
+        with self.assertRaises(KeyError):
+            # error when:
+            # - the provided dataset_input_key does not exist in inputs
+            self.transformer_input_key.etl({"df": self.df})
+
+    def test_process_many_input_key_list(self):
+        # process_many is called when:
+        # - dataset_input_key_list is given
+        result = self.transformer_input_key_list.etl(
+            {"my_input_key_1": self.df, "my_input_key_2": self.df}
+        )
+        self.assertEqual(6, list(result.values())[2].count())
+
+        with self.assertRaises(AssertionError):
+            # error when:
+            # - the provided dataset_input_key_list contains an incorrect key
+            self.transformer_input_key_list.etl({"df1": self.df, "df2": self.df})
+
+
+class TestTransformer(ExtendedTransformer):
+    def process(self, df: DataFrame) -> DataFrame:
+        return df
+
+    def process_many(self, datasets: dataset_group) -> DataFrame:
+        assert len(datasets) == 2
+        df1, df2 = list(datasets.values())
+        return df1.union(df2)
+
+
+def create_dataframe():
+
+    data = [(1, "1"), (2, "2"), (3, "3")]
+
+    schema = StructType(
+        [
+            StructField("id", IntegerType(), False),
+            StructField("text", StringType(), False),
+        ]
+    )
+
+    return Spark.get().createDataFrame(data=data, schema=schema)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cluster/etl/test_transformer.py
+++ b/tests/cluster/etl/test_transformer.py
@@ -25,6 +25,10 @@ class TransformerTests(unittest.TestCase):
         self.assertEqual({"TestTransformer"}, set(result.keys()))
         self.assertEqual(6, list(result.values())[0].count())
 
+    def test_dataset_key(self):
+        result = TestTransformer("my_key").etl({"df": self.df})
+        self.assertEqual({"my_key"}, set(result.keys()))
+
 
 class TestTransformer(Transformer):
     def process(self, df: DataFrame) -> DataFrame:
@@ -37,15 +41,17 @@ class TestTransformer(Transformer):
 
 
 def create_dataframe():
-    return Spark.get().createDataFrame(
-        Spark.get().sparkContext.parallelize([(1, "1"), (2, "2"), (3, "3")]),
-        StructType(
-            [
-                StructField("id", IntegerType(), False),
-                StructField("text", StringType(), False),
-            ]
-        ),
+
+    data = [(1, "1"), (2, "2"), (3, "3")]
+
+    schema = StructType(
+        [
+            StructField("id", IntegerType(), False),
+            StructField("text", StringType(), False),
+        ]
     )
+
+    return Spark.get().createDataFrame(data=data, schema=schema)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR introduces the ExtendedTransformer and ExtendedLoader core classes. 

The ExtendedTransformer class will not consume the input dataset. A transformer, which inherits from this extended class, will therefore append to the existing dataset of keys and dataframes. This will allow for greater flexibility in etl flows, thus allowing the user to reuse dataframes, by not "loosing" them to a transformer. The ExtendedTransformer class uses input- and output key(s) to ensure transformation of the desired dataframes as well as allowing the user to have complete control of the output frame. The ExtendedTransformer returns a single dataframe. 

The ExtendedLoader class has the same functionality as the core Loader class, but it will also handle input key(s). It is crucial to be able to pass these keys in the load (etl step), such that the ExtendedLoader knows which dataframe(s) to save.

These functionalities have all been added with relevant unit tests.