### PR TITLE
allow delta handle with path only

### DIFF
--- a/tests/cluster/delta/extras/tablenames.yml
+++ b/tests/cluster/delta/extras/tablenames.yml
@@ -6,6 +6,9 @@ SparkTestTable1:
   name: "{SparkTestDb}.tbl1"
   path: "{SparkTestDb_path}/tbl1"
 
+SparkTestTable11:
+  path: "{SparkTestDb_path}/tbl11"
+
 SparkTestDb2:
   name: my_db2{ID}
   path: /tmp/foo/bar/my_db2/

--- a/tests/cluster/delta/test_delta_class.py
+++ b/tests/cluster/delta/test_delta_class.py
@@ -36,6 +36,13 @@ class DeltaTests(unittest.TestCase):
             },
         )
 
+        tc.register(
+            "MyTbl3",
+            {
+                "path": "/mnt/atc/silver/testdb/testtbl3",
+            },
+        )
+
         # test instantiation without error
         DbHandle.from_tc("MyDb")
         DeltaHandle.from_tc("MyTbl")
@@ -95,3 +102,13 @@ class DeltaTests(unittest.TestCase):
 
         with self.assertRaises(AnalysisException):
             dh.read()
+
+    def test_08_write_path_only(self):
+        # check that we can write to the table with no path
+        df = DeltaHandle.from_tc("MyTbl").read()
+
+        dh3 = DeltaHandle.from_tc("MyTbl3")
+        dh3.append(df, mergeSchema=True)
+
+        df = dh3.read()
+        df.show()

--- a/tests/cluster/delta/test_delta_class.py
+++ b/tests/cluster/delta/test_delta_class.py
@@ -96,19 +96,20 @@ class DeltaTests(unittest.TestCase):
         o.load_into(SimpleLoader(DeltaHandle.from_tc("MyTbl"), mode="overwrite"))
         o.execute()
 
-    def test_07_delete(self):
+    def test_07_write_path_only(self):
+        # check that we can write to the table with no path
+        df = DeltaHandle.from_tc("MyTbl").read()
+
+        dh3 = DeltaHandle.from_tc("MyTbl3")
+
+        dh3.append(df, mergeSchema=True)
+
+        df = dh3.read()
+        df.show()
+
+    def test_08_delete(self):
         dh = DeltaHandle.from_tc("MyTbl")
         dh.drop_and_delete()
 
         with self.assertRaises(AnalysisException):
             dh.read()
-
-    def test_08_write_path_only(self):
-        # check that we can write to the table with no path
-        df = DeltaHandle.from_tc("MyTbl").read()
-
-        dh3 = DeltaHandle.from_tc("MyTbl3")
-        dh3.append(df, mergeSchema=True)
-
-        df = dh3.read()
-        df.show()


### PR DESCRIPTION
The delta handle already uses the path to read and write tables if the path is given. The name should therefore be optional.
Today the name is mandatory. This PR makes it optional.
We still require either the name or the path to be given.
If only the path is given, the name is set to `` delta.`/path` `` to still allow for stuff like `TRUNCATE` 