### PR TITLE
check both test and prod for version

### DIFF
--- a/utilities/manipulate_version.py
+++ b/utilities/manipulate_version.py
@@ -13,7 +13,7 @@ version_file_path = "src/VERSION.txt"
 
 def main():
     # find out what version to use
-    pypi_v = get_test_pypi_version()
+    pypi_v = max(get_version("test.pypi.org"), get_version("pypi.org"))
     local_v = get_local_version()
     if local_v > pypi_v:
         version = local_v.base_version
@@ -32,11 +32,9 @@ def get_local_version():
         return v
 
 
-def get_test_pypi_version():
+def get_version(host):
     try:
-        test_pypi = json.load(
-            urlopen("https://test.pypi.org/pypi/atc-dataplatform/json")
-        )
+        test_pypi = json.load(urlopen(f"https://{host}/pypi/atc-dataplatform/json"))
         test_pypi_version = parse(test_pypi["info"]["version"])
         return test_pypi_version
     except:  # noqa: E722


### PR DESCRIPTION
for some reason the link here
[https://test.pypi.org/pypi/atc-dataplatform/json](https://test.pypi.org/pypi/atc-dataplatform/json)
currently claims the current version is 1.0.46
even though here 
[https://test.pypi.org/project/atc-dataplatform/](https://test.pypi.org/project/atc-dataplatform/)
it is 1.0.47
The post-merge pipline fails because 1.0.47 exists.
When I check the production version, at 
[https://pypi.org/pypi/atc-dataplatform/json](https://pypi.org/pypi/atc-dataplatform/json)
it says 1.0.47, so by considering the highest of either api, we will be goo again.

Another nice effect of this is that we can always re-run the release pipe to re-publish with the next higher version number now.