### PR TITLE
Update to the UnionTransformer and adding a non-consuming version of it

### DIFF
--- a/src/atc/transformers/__init__.py
+++ b/src/atc/transformers/__init__.py
@@ -4,3 +4,4 @@ from .drop_oldest_duplicate_transformer import (  # noqa: F401
 from .simple_sql_transformer import SimpleSqlServerTransformer  # noqa: F401
 from .timezone_transformer import TimeZoneTransformer  # noqa: F401
 from .union_transformer import UnionTransformer  # noqa: F401
+from .union_transformer_nc import UnionTransformerNC  # noqa: F401

--- a/src/atc/transformers/union_transformer_nc.py
+++ b/src/atc/transformers/union_transformer_nc.py
@@ -1,0 +1,54 @@
+from functools import reduce
+from typing import List
+
+from pyspark.sql import DataFrame
+
+from atc.etl import ExtendedTransformer
+from atc.etl.types import dataset_group
+
+
+class UnionTransformerNC(ExtendedTransformer):
+    """
+    This non-consuming transformer unions multiple DataFrames
+
+    Attributes:
+    ----------
+        allowMissingColumns : bool
+            When the parameter allowMissingColumns is True,
+            the set of column names in this and other DataFrame
+            can differ; missing columns will be filled with null
+
+    Methods
+    -------
+    process(df: DataFrame):
+        returns the input DataFrame
+
+    process_many(datasets: dataset_group):
+        returns the union of all input DataFrames
+    """
+
+    def __init__(
+        self,
+        dataset_input_key: str = None,
+        dataset_input_key_list: List[str] = None,
+        dataset_output_key: str = None,
+        allowMissingColumns: bool = False,
+    ):
+        super().__init__(
+            dataset_input_key=dataset_input_key,
+            dataset_input_key_list=dataset_input_key_list,
+            dataset_output_key=dataset_output_key,
+        )
+        self.allowMissingColumns = allowMissingColumns
+
+    def process(self, df: DataFrame) -> DataFrame:
+        return df
+
+    def process_many(self, datasets: dataset_group) -> DataFrame:
+        dfs = list(datasets.values())
+        return reduce(
+            lambda df1, df2: df1.unionByName(
+                df2, allowMissingColumns=self.allowMissingColumns
+            ),
+            dfs,
+        )

--- a/tests/local/transformers/test_union_transformer.py
+++ b/tests/local/transformers/test_union_transformer.py
@@ -1,0 +1,126 @@
+import pyspark.sql.types as T
+from atc_tools.testing import DataframeTestCase
+
+from atc.spark import Spark
+from atc.transformers import UnionTransformer
+
+
+class TestUnionTransformer(DataframeTestCase):
+    def test_union_two_dataframes(self):
+        input_schema = T.StructType(
+            [
+                T.StructField("Col1", T.StringType(), True),
+                T.StructField("Col2", T.IntegerType(), True),
+                T.StructField("Col3", T.DoubleType(), True),
+                T.StructField("Col4", T.StringType(), True),
+                T.StructField("Col5", T.StringType(), True),
+            ]
+        )
+
+        input_data1 = [("Col1Data", 42, 13.37, "Col4Data", "Col5Data")]
+        input_data2 = [("Col1Data_2nd", 42, 13.37, "Col4Data_2nd", "Col5Data_2nd")]
+
+        input_df_1 = Spark.get().createDataFrame(data=input_data1, schema=input_schema)
+        input_df_2 = Spark.get().createDataFrame(data=input_data2, schema=input_schema)
+        input_datasets = {"DF1": input_df_1, "DF2": input_df_2}
+
+        transformed_df = UnionTransformer().process_many(input_datasets)
+
+        expected_data = [
+            ("Col1Data", 42, 13.37, "Col4Data", "Col5Data"),
+            ("Col1Data_2nd", 42, 13.37, "Col4Data_2nd", "Col5Data_2nd"),
+        ]
+
+        self.assertDataframeMatches(
+            df=transformed_df,
+            expected_data=expected_data,
+        )
+
+    def test_union_three_dataframes(self):
+        input_schema = T.StructType(
+            [
+                T.StructField("Col1", T.StringType(), True),
+                T.StructField("Col2", T.IntegerType(), True),
+                T.StructField("Col3", T.DoubleType(), True),
+                T.StructField("Col4", T.StringType(), True),
+                T.StructField("Col5", T.StringType(), True),
+            ]
+        )
+
+        input_data1 = [("Col1Data", 42, 13.37, "Col4Data", "Col5Data")]
+        input_data2 = [("Col1Data_2nd", 42, 13.37, "Col4Data_2nd", "Col5Data_2nd")]
+        input_data3 = [
+            (
+                "Totally new data",
+                1234,
+                98.76,
+                "More totally new data",
+                "Again, totally new data",
+            )
+        ]
+
+        input_df_1 = Spark.get().createDataFrame(data=input_data1, schema=input_schema)
+        input_df_2 = Spark.get().createDataFrame(data=input_data2, schema=input_schema)
+        input_df_3 = Spark.get().createDataFrame(data=input_data3, schema=input_schema)
+        input_datasets = {"DF1": input_df_1, "DF2": input_df_2, "DF3": input_df_3}
+
+        transformed_df = UnionTransformer().process_many(input_datasets)
+
+        expected_data = [
+            ("Col1Data", 42, 13.37, "Col4Data", "Col5Data"),
+            ("Col1Data_2nd", 42, 13.37, "Col4Data_2nd", "Col5Data_2nd"),
+            (
+                "Totally new data",
+                1234,
+                98.76,
+                "More totally new data",
+                "Again, totally new data",
+            ),
+        ]
+
+        self.assertDataframeMatches(df=transformed_df, expected_data=expected_data)
+
+    def test_union_dataframes_missing_columns(self):
+        input_schema1 = T.StructType(
+            [
+                T.StructField("Col1", T.StringType(), True),
+                T.StructField("Col2", T.IntegerType(), True),
+                T.StructField("Col3", T.DoubleType(), True),
+                T.StructField("Col4", T.StringType(), True),
+                T.StructField("Col5", T.StringType(), True),
+            ]
+        )
+        input_data1 = [
+            (
+                "Col1Data",
+                42,
+                13.37,
+                "Col4Data",
+                "Col5Data",
+            )
+        ]
+
+        input_schema2 = T.StructType(
+            [
+                T.StructField("Col1", T.StringType(), True),
+                T.StructField("Col2", T.IntegerType(), True),
+                T.StructField("Col3", T.DoubleType(), True),
+                T.StructField("Col4", T.StringType(), True),
+            ]
+        )
+        input_data2 = [("Col1Data_2nd", 42, 13.37, "Col4Data_2nd")]
+
+        input_df_1 = Spark.get().createDataFrame(data=input_data1, schema=input_schema1)
+        input_df_2 = Spark.get().createDataFrame(data=input_data2, schema=input_schema2)
+        input_datasets = {"DF1": input_df_1, "DF2": input_df_2}
+
+        transformed_df = UnionTransformer(allowMissingColumns=True).process_many(
+            input_datasets
+        )
+
+        expected_data = [
+            ("Col1Data", 42, 13.37, "Col4Data", "Col5Data"),
+            ("Col1Data_2nd", 42, 13.37, "Col4Data_2nd", None),
+        ]
+
+        self.assertDataframeMatches(df=transformed_df, expected_data=expected_data)

--- a/tests/local/transformers/test_union_transformer_nc.py
+++ b/tests/local/transformers/test_union_transformer_nc.py
@@ -1,0 +1,126 @@
+import pyspark.sql.types as T
+from atc_tools.testing import DataframeTestCase
+
+from atc.spark import Spark
+from atc.transformers import UnionTransformerNC
+
+
+class TestUnionTransformer(DataframeTestCase):
+    def test_union_two_dataframes(self):
+        input_schema = T.StructType(
+            [
+                T.StructField("Col1", T.StringType(), True),
+                T.StructField("Col2", T.IntegerType(), True),
+                T.StructField("Col3", T.DoubleType(), True),
+                T.StructField("Col4", T.StringType(), True),
+                T.StructField("Col5", T.StringType(), True),
+            ]
+        )
+
+        input_data1 = [("Col1Data", 42, 13.37, "Col4Data", "Col5Data")]
+        input_data2 = [("Col1Data_2nd", 42, 13.37, "Col4Data_2nd", "Col5Data_2nd")]
+
+        input_df_1 = Spark.get().createDataFrame(data=input_data1, schema=input_schema)
+        input_df_2 = Spark.get().createDataFrame(data=input_data2, schema=input_schema)
+        input_datasets = {"DF1": input_df_1, "DF2": input_df_2}
+
+        transformed_df = UnionTransformerNC().process_many(input_datasets)
+
+        expected_data = [
+            ("Col1Data", 42, 13.37, "Col4Data", "Col5Data"),
+            ("Col1Data_2nd", 42, 13.37, "Col4Data_2nd", "Col5Data_2nd"),
+        ]
+
+        self.assertDataframeMatches(
+            df=transformed_df,
+            expected_data=expected_data,
+        )
+
+    def test_union_three_dataframes(self):
+        input_schema = T.StructType(
+            [
+                T.StructField("Col1", T.StringType(), True),
+                T.StructField("Col2", T.IntegerType(), True),
+                T.StructField("Col3", T.DoubleType(), True),
+                T.StructField("Col4", T.StringType(), True),
+                T.StructField("Col5", T.StringType(), True),
+            ]
+        )
+
+        input_data1 = [("Col1Data", 42, 13.37, "Col4Data", "Col5Data")]
+        input_data2 = [("Col1Data_2nd", 42, 13.37, "Col4Data_2nd", "Col5Data_2nd")]
+        input_data3 = [
+            (
+                "Totally new data",
+                1234,
+                98.76,
+                "More totally new data",
+                "Again, totally new data",
+            )
+        ]
+
+        input_df_1 = Spark.get().createDataFrame(data=input_data1, schema=input_schema)
+        input_df_2 = Spark.get().createDataFrame(data=input_data2, schema=input_schema)
+        input_df_3 = Spark.get().createDataFrame(data=input_data3, schema=input_schema)
+        input_datasets = {"DF1": input_df_1, "DF2": input_df_2, "DF3": input_df_3}
+
+        transformed_df = UnionTransformerNC().process_many(input_datasets)
+
+        expected_data = [
+            ("Col1Data", 42, 13.37, "Col4Data", "Col5Data"),
+            ("Col1Data_2nd", 42, 13.37, "Col4Data_2nd", "Col5Data_2nd"),
+            (
+                "Totally new data",
+                1234,
+                98.76,
+                "More totally new data",
+                "Again, totally new data",
+            ),
+        ]
+
+        self.assertDataframeMatches(df=transformed_df, expected_data=expected_data)
+
+    def test_union_dataframes_missing_columns(self):
+        input_schema1 = T.StructType(
+            [
+                T.StructField("Col1", T.StringType(), True),
+                T.StructField("Col2", T.IntegerType(), True),
+                T.StructField("Col3", T.DoubleType(), True),
+                T.StructField("Col4", T.StringType(), True),
+                T.StructField("Col5", T.StringType(), True),
+            ]
+        )
+        input_data1 = [
+            (
+                "Col1Data",
+                42,
+                13.37,
+                "Col4Data",
+                "Col5Data",
+            )
+        ]
+
+        input_schema2 = T.StructType(
+            [
+                T.StructField("Col1", T.StringType(), True),
+                T.StructField("Col2", T.IntegerType(), True),
+                T.StructField("Col3", T.DoubleType(), True),
+                T.StructField("Col4", T.StringType(), True),
+            ]
+        )
+        input_data2 = [("Col1Data_2nd", 42, 13.37, "Col4Data_2nd")]
+
+        input_df_1 = Spark.get().createDataFrame(data=input_data1, schema=input_schema1)
+        input_df_2 = Spark.get().createDataFrame(data=input_data2, schema=input_schema2)
+        input_datasets = {"DF1": input_df_1, "DF2": input_df_2}
+
+        transformed_df = UnionTransformerNC(allowMissingColumns=True).process_many(
+            input_datasets
+        )
+
+        expected_data = [
+            ("Col1Data", 42, 13.37, "Col4Data", "Col5Data"),
+            ("Col1Data_2nd", 42, 13.37, "Col4Data_2nd", None),
+        ]
+
+        self.assertDataframeMatches(df=transformed_df, expected_data=expected_data)


### PR DESCRIPTION
Creating a non-consuming version of the UnionTransformer and adding a unittest.

Ensuring that the code for the consuming and non-consuming version is aligned.

