### PR TITLE
fix singleton behavior

### DIFF
--- a/src/atc/configurator/configurator.py
+++ b/src/atc/configurator/configurator.py
@@ -30,9 +30,11 @@ class ConfiguratorSingleton(type):
     _instance = None
 
     def __call__(cls, *args, **kwargs):
-        if cls._instance is None:
-            cls._instance = super(ConfiguratorSingleton, cls).__call__(*args, **kwargs)
-        return cls._instance
+        if ConfiguratorSingleton._instance is None:
+            ConfiguratorSingleton._instance = super(
+                ConfiguratorSingleton, cls
+            ).__call__(*args, **kwargs)
+        return ConfiguratorSingleton._instance
 
 
 class Configurator(metaclass=ConfiguratorSingleton):

--- a/tests/local/configurator/test_configurator.py
+++ b/tests/local/configurator/test_configurator.py
@@ -77,7 +77,12 @@ class TestConfigurator(unittest.TestCase):
         self.assertEqual(tc.table_name("MyComposite"), "ottoBar")
 
     def test_08_test_deprecated_import(self):
+        from atc import Configurator
         from atc.config_master import TableConfigurator
 
         tc = TableConfigurator()
         self.assertEqual(tc.table_name("MyComposite"), "ottoBar")
+
+        c = Configurator()
+
+        self.assertIs(tc, c)


### PR DESCRIPTION
The two names Configurator and TableConfigurator did nor return the same object, That was not by design. This is fixed now.