### PR TITLE
feat: use left anti to check if merge is needed

### DIFF
--- a/src/atc/delta/delta_handle.py
+++ b/src/atc/delta/delta_handle.py
@@ -186,8 +186,6 @@ class DeltaHandle(TableHandle):
         df, merge_required = CheckDfMerge(
             df=df,
             df_target=df_target,
-            join_cols=join_cols,
-            avoid_cols=[],
         )
 
         if not merge_required:


### PR DESCRIPTION
Since left-anti join returns values from the left relation that has no match with the right - the checkmerge statement could join the source_df and target_df on ALL columns. 

If there is any data left after applying the left-anti...

on = all_columns
how=left_anti