### PR TITLE
Feature/tab lock write sql

### DIFF
--- a/src/atc/sql/SqlServer.py
+++ b/src/atc/sql/SqlServer.py
@@ -159,6 +159,12 @@ class SqlServer:
         ).mode("append" if append else "overwrite").option(
             "schemaCheckEnabled", False
         ).option(
+            # https://learn.microsoft.com/en-us/sql/connect/spark/connector?view=sql-server-ver16#supported-options
+            # https://github.com/microsoft/sql-spark-connector/blob/master/README.md
+            # Implements an insert with TABLOCK option to improve write performance
+            "tableLock",
+            True,
+        ).option(
             "batchSize", batch_size
         ).option(
             "truncate", not append

--- a/tests/cluster/sql/test_deliverysql.py
+++ b/tests/cluster/sql/test_deliverysql.py
@@ -309,6 +309,19 @@ class DeliverySqlServerTests(DataframeTestCase):
             expected_data=expectedData,
         )
 
+    def test20_big_data_set(self):
+        # Ensure table creation
+        self.sql_server.drop_table(self.table_name)
+        self.create_test_table()
+
+        # Create test data
+        df = self.create_data()
+
+        # Write as big data set
+        self.sql_server.write_table(df, self.table_name, big_data_set=True)
+        df_with_data = self.sql_server.read_table(self.table_name)
+        self.assertEqual(df_with_data.count(), 1)
+
     def create_test_table(self):
         sql_argument = f"""
             IF OBJECT_ID('{self.table_name}', 'U') IS NULL

--- a/tests/cluster/sql/test_deliverysql.py
+++ b/tests/cluster/sql/test_deliverysql.py
@@ -311,15 +311,15 @@ class DeliverySqlServerTests(DataframeTestCase):
 
     def test20_big_data_set(self):
         # Ensure table creation
-        self.sql_server.drop_table(self.table_name)
+        self.sql_server.drop_table_by_name(self.table_name)
         self.create_test_table()
 
         # Create test data
         df = self.create_data()
 
         # Write as big data set
-        self.sql_server.write_table(df, self.table_name, big_data_set=True)
-        df_with_data = self.sql_server.read_table(self.table_name)
+        self.sql_server.write_table_by_name(df, self.table_name, big_data_set=True)
+        df_with_data = self.sql_server.read_table_by_name(self.table_name)
         self.assertEqual(df_with_data.count(), 1)
 
     def create_test_table(self):


### PR DESCRIPTION
To improve the write opreration to SQL server the SqlServer class should use TabLock.

tableLock= TRUE 
*Implements an insert with TABLOCK option to improve write performance*
https://learn.microsoft.com/en-us/sql/connect/spark/connector?view=sql-server-ver16#supported-options

Microsoft has also done performance comparisons of the mssql connector using TABLOCK. See: 
https://github.com/microsoft/sql-spark-connector/blob/master/README.md#performance-comparison

See also:
https://learn.microsoft.com/en-us/sql/connect/jdbc/using-bulk-copy-with-the-jdbc-driver?view=sql-server-ver16