### PR TITLE
add case insensitive matching

### DIFF
--- a/src/atc/transformers/simple_sql_transformer.py
+++ b/src/atc/transformers/simple_sql_transformer.py
@@ -7,15 +7,11 @@ from atc.utils import SelectAndCastColumns
 
 
 class SimpleSqlServerTransformer(Transformer):
-    def __init__(
-        self,
-        *,
-        table_id: str,
-        server: SqlServer,
-    ):
+    def __init__(self, *, table_id: str, server: SqlServer, ignoreCase=False):
         super().__init__()
         self.server = server
         self.table_id = table_id
+        self.ignoreCase = ignoreCase
 
     def process(self, df: DataFrame) -> DataFrame:
         # This transformation ensures that the selected columns
@@ -23,7 +19,9 @@ class SimpleSqlServerTransformer(Transformer):
         # [f.col("ColumnName).cast("string").alias("ColumnName"), ...]
 
         df = SelectAndCastColumns(
-            df=df, schema=self.server.read_table(self.table_id).schema
+            df=df,
+            schema=self.server.read_table(self.table_id).schema,
+            caseInsensitiveMatching=self.ignoreCase,
         )
 
         # If the format is timestamp, the seconds should be trunc

--- a/tests/cluster/sql/test_simple_sql_etl.py
+++ b/tests/cluster/sql/test_simple_sql_etl.py
@@ -1,5 +1,4 @@
-import unittest
-
+from atc_tools.testing import DataframeTestCase
 from atc_tools.time import dt_utc
 from pyspark.sql import DataFrame
 from pyspark.sql.types import (
@@ -15,12 +14,13 @@ from pyspark.sql.types import (
 from atc import Configurator
 from atc.etl.loaders import SimpleLoader
 from atc.functions import get_unique_tempview_name
+from atc.spark import Spark
 from atc.transformers.simple_sql_transformer import SimpleSqlServerTransformer
 from atc.utils import DataframeCreator
 from tests.cluster.sql.DeliverySqlServer import DeliverySqlServer
 
 
-class SimpleSqlServerETLTests(unittest.TestCase):
+class SimpleSqlServerETLTests(DataframeTestCase):
     tc = None
     sql_server = None
     table_name = "dbo.Test1" + get_unique_tempview_name()
@@ -78,7 +78,17 @@ class SimpleSqlServerETLTests(unittest.TestCase):
         self.assertEqual(df_out.schema, schema_expected)
 
     def test02_can_transform_and_load(self):
-        df = self.create_data()
+
+        # mix up the column spelling to test case-insensitive matching this time
+        df = Spark.get().createDataFrame(
+            [(123, 1001.322, "Hello", dt_utc(2021, 1, 1, 14, 45, 22, 32))],
+            """
+                TeStCoLuMn INT,
+                TESTcolumn2 DOUBLE,
+                testCOLUMN3 STRING,
+                TestColumn4 TIMESTAMP
+            """,
+        )
 
         # Use transformer
         df_out = SimpleSqlServerTransformer(
@@ -90,7 +100,11 @@ class SimpleSqlServerETLTests(unittest.TestCase):
         df_with_data = self.sql_server.read_table(self.table_id)
 
         # Test that the datarow can be read
-        self.assertEqual(df_with_data.count(), 1)
+        self.assertDataframeMatches(
+            df_with_data,
+            None,
+            [(123, 1001.322, "Hello", dt_utc(2021, 1, 1, 14, 45, 22, 32))],
+        )
 
     def create_test_table(self):
         sql_argument = f"""

--- a/tests/cluster/sql/test_simple_sql_etl.py
+++ b/tests/cluster/sql/test_simple_sql_etl.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from atc_tools.testing import DataframeTestCase
 from atc_tools.time import dt_utc
 from pyspark.sql import DataFrame
@@ -92,7 +94,7 @@ class SimpleSqlServerETLTests(DataframeTestCase):
 
         # Use transformer
         df_out = SimpleSqlServerTransformer(
-            table_id=self.table_id, server=self.sql_server
+            table_id=self.table_id, server=self.sql_server, ignoreCase=True
         ).process(df)
 
         SimpleLoader(handle=self.sql_server.from_tc(self.table_id)).save(df_out)
@@ -103,7 +105,7 @@ class SimpleSqlServerETLTests(DataframeTestCase):
         self.assertDataframeMatches(
             df_with_data,
             None,
-            [(123, 1001.322, "Hello", dt_utc(2021, 1, 1, 14, 45, 22, 32))],
+            [(123, Decimal("1001.322"), "Hello", dt_utc(2021, 1, 1, 14, 45, 22))],
         )
 
     def create_test_table(self):


### PR DESCRIPTION
Changing the SqlServerTransformer to be case-sensitive by default broke our pipeline. This happended in pr #211. This option adds the old behavior back in as an option.