### PR TITLE
fix: Remove trailing 0 in datetime string milliseconds for TestSelect…

### DIFF
--- a/tests/local/utils/test_selectandcastcolumns.py
+++ b/tests/local/utils/test_selectandcastcolumns.py
@@ -155,7 +155,7 @@ class TestSelectAndCastColumns(DataframeTestCase):
                 1,
                 0,
                 datetime_to_use,
-                datetime_to_use.strftime("%Y-%m-%d %H:%M:%S.%f"),
+                datetime_to_use.strftime("%Y-%m-%d %H:%M:%S.%f").rstrip("0"),
             )
         ]
 


### PR DESCRIPTION
Fixed bug in SelectAndCastColumns unit test.

This is a fix for issue: https://github.com/atc-net/atc-dataplatform/issues/224

Spark datetime to string is removing trailing 0 in milliseconds, this cased an error when milliseconds happened to have 5 instead of 6 decimals. The test have been adapt to same behaviour.