### PR TITLE
schema extractor

### DIFF
--- a/src/atc/etl/extractors/schema_extractor.py
+++ b/src/atc/etl/extractors/schema_extractor.py
@@ -1,0 +1,20 @@
+from pyspark.sql import DataFrame
+from pyspark.sql import functions as f
+
+from atc.etl import Extractor
+from atc.etl.extractors.simple_extractor import Readable
+
+
+class SchemaExtractor(Extractor):
+    """This extractor will extract from any object that has a .read() method,
+    the resulting data frame will have zero rows and is intended for schema
+    manipulation only."""
+
+    def __init__(self, handle: Readable, dataset_key: str):
+        super().__init__(dataset_key=dataset_key)
+        self.handle = handle
+
+    def read(self) -> DataFrame:
+        df = self.handle.read()
+        df = df.where(f.lit(False))
+        return df

--- a/tests/cluster/delta/test_delta_class.py
+++ b/tests/cluster/delta/test_delta_class.py
@@ -6,6 +6,7 @@ from atc import Configurator
 from atc.delta import DbHandle, DeltaHandle
 from atc.etl import Orchestrator
 from atc.etl.extractors import SimpleExtractor
+from atc.etl.extractors.schema_extractor import SchemaExtractor
 from atc.etl.loaders import SimpleLoader
 from atc.spark import Spark
 
@@ -81,6 +82,17 @@ class DeltaTests(unittest.TestCase):
     def test_04_read(self):
         df = DeltaHandle.from_tc("MyTbl").read()
         self.assertEqual(6, df.count())
+
+    def test_041_schema(self):
+        """Schema Extractor returns zero lines, but preserves the schema,
+        giving more readable orchestrators"""
+        df1 = SimpleExtractor(DeltaHandle.from_tc("MyTbl"), "MyTbl").read()
+        self.assertEqual(6, df1.count())
+
+        df2 = SchemaExtractor(DeltaHandle.from_tc("MyTbl"), "MyTbl").read()
+        self.assertEqual(0, df2.count())
+
+        self.assertEqual(df1.schema, df2.schema)
 
     def test_05_truncate(self):
         dh = DeltaHandle.from_tc("MyTbl")


### PR DESCRIPTION
To support writing clean Transformers, this extractor always returns empty data frames for cases where only the schema is needed.