### PR TITLE
strip semicolon

### DIFF
--- a/src/atc/sql/SqlExecutor.py
+++ b/src/atc/sql/SqlExecutor.py
@@ -91,12 +91,16 @@ class SqlExecutor:
 
                     for statement in parse(sql_code):
                         cleaned_statement = (
-                            "".join(
-                                token.value
-                                for token in statement
-                                if token.ttype not in sqlparse.tokens.Comment
+                            (
+                                "".join(
+                                    token.value
+                                    for token in statement
+                                    if token.ttype not in sqlparse.tokens.Comment
+                                )
                             )
-                        ).strip()
+                            .strip()
+                            .strip(";")
+                        )
 
                         full_statement = "".join(token.value for token in statement)
 

--- a/tests/local/configurator/test_configurator.py
+++ b/tests/local/configurator/test_configurator.py
@@ -135,9 +135,12 @@ class TestConfigurator(unittest.TestCase):
             SchemaManager().get_schema_as_string("MyDetailsTable"),
             """a int, b int, c string, d timestamp, another int""",
         )
+
         c.set_prod()
+        statements = list(SqlExecutor(sql).get_statements("*"))
+        self.assertEqual(len(statements), 3)
         self.assertEqual(
-            list(SqlExecutor(sql).get_statements("*"))[1],
+            statements[1],
             dedent(
                 """\
 


### PR DESCRIPTION
a statement consisting only of a semicolon was previously considered a valid statement. Spark.sql still complains about it. This test will skip such statements.