### PR TITLE
feat: Add dataset_input_keys to SimpleLoader and UpsertLoader

### DIFF
--- a/src/atc/etl/loaders/UpsertLoader.py
+++ b/src/atc/etl/loaders/UpsertLoader.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Union
 
 from pyspark.sql import DataFrame
 
@@ -7,8 +7,13 @@ from atc.tables import TableHandle
 
 
 class UpsertLoader(Loader):
-    def __init__(self, handle: TableHandle, join_cols: List[str]):
-        super().__init__()
+    def __init__(
+        self,
+        handle: TableHandle,
+        join_cols: List[str],
+        dataset_input_keys: Union[str, List[str]] = None,
+    ):
+        super().__init__(dataset_input_keys=dataset_input_keys)
 
         self.handle = handle
         self.join_cols = join_cols

--- a/src/atc/etl/loaders/simple_loader.py
+++ b/src/atc/etl/loaders/simple_loader.py
@@ -1,4 +1,4 @@
-from typing import Protocol, Union
+from typing import List, Protocol, Union
 
 from pyspark.sql import DataFrame
 
@@ -17,9 +17,13 @@ class Appendable(Protocol):
 
 class SimpleLoader(Loader):
     def __init__(
-        self, handle: Union[Overwritable, Appendable], *, mode: str = "overwrite"
+        self,
+        handle: Union[Overwritable, Appendable],
+        *,
+        mode: str = "overwrite",
+        dataset_input_keys: Union[str, List[str]] = None,
     ):
-        super().__init__()
+        super().__init__(dataset_input_keys=dataset_input_keys)
         self.mode = mode
         self.handle = handle
 


### PR DESCRIPTION
The base Loader have input dataset_input_keys to control flow.

This PR adds dataset_input_keys to SimpleLoader and UpsertLoader to have same function using these Loaders.