### PR TITLE
feat: eh2delta append use incremental extract

### DIFF
--- a/src/atc/exceptions/__init__.py
+++ b/src/atc/exceptions/__init__.py
@@ -50,3 +50,8 @@ class NoDbUtils(AtcException):
 
 class NoSuchValueException(AtcKeyError):
     pass
+
+
+class MissingUpsertJoinColumns(AtcKeyError):
+    value = "You must specify upsert_join_cols"
+    pass

--- a/src/atc/orchestrators/eh2silver/EhToDeltaSilverOrchestrator.py
+++ b/src/atc/orchestrators/eh2silver/EhToDeltaSilverOrchestrator.py
@@ -5,6 +5,7 @@ from atc.etl import EtlBase, Orchestrator
 from atc.etl.extractors import IncrementalExtractor, SimpleExtractor
 from atc.etl.loaders import SimpleLoader
 from atc.etl.loaders.UpsertLoader import UpsertLoader
+from atc.exceptions import MissingUpsertJoinColumns
 from atc.orchestrators.ehjson2delta.EhJsonToDeltaTransformer import (
     EhJsonToDeltaTransformer,
 )
@@ -41,8 +42,10 @@ class EhToDeltaSilverOrchestrator(Orchestrator):
 
         # step 1
         # Extracts the data from the bronze layer
-        if mode == "upsert":
-            assert upsert_join_cols is not None, "You must specify upsert_join_cols"
+        if mode == "upsert" or mode == "append":
+            if mode == "upsert":
+                if upsert_join_cols is None:
+                    raise MissingUpsertJoinColumns
             self.extract_from(
                 IncrementalExtractor(
                     handle_source=self.dh_source,

--- a/tests/local/eh/test_ehtodeltasilver_orchestrator.py
+++ b/tests/local/eh/test_ehtodeltasilver_orchestrator.py
@@ -8,6 +8,7 @@ from atc.etl import Transformer
 from atc.etl.extractors import IncrementalExtractor, SimpleExtractor
 from atc.etl.loaders import SimpleLoader
 from atc.etl.loaders.UpsertLoader import UpsertLoader
+from atc.exceptions import MissingUpsertJoinColumns
 from atc.orchestrators import EhToDeltaSilverOrchestrator
 from atc.orchestrators.ehjson2delta.EhJsonToDeltaTransformer import (
     EhJsonToDeltaTransformer,
@@ -41,7 +42,60 @@ class EhToDeltaSilverOrchestratorTests(DataframeTestCase):
                     p1.assert_called_once()
                     p2.assert_called_once()
 
-    def test_02_w_transformer(self):
+    def test_02_input_upsert(self):
+        test_df = Spark.get().createDataFrame(
+            [], schema="id string, EnqueuedTimestamp timestamp"
+        )
+        dh_source_mock = Mock()
+        dh_source_mock.read = Mock(return_value=test_df)
+        dh_target_mock = Mock()
+        dh_target_mock.read = Mock(return_value=test_df)
+
+        with patch.object(IncrementalExtractor, "read", return_value=test_df) as p0:
+            with patch.object(
+                EhJsonToDeltaTransformer, "process", return_value=test_df
+            ) as p1:
+                with patch.object(UpsertLoader, "save", return_value=test_df) as p2:
+                    orchestrator = EhToDeltaSilverOrchestrator(
+                        dh_source=dh_source_mock,
+                        dh_target=dh_target_mock,
+                        mode="upsert",
+                        upsert_join_cols=["id"],
+                    )
+                    orchestrator.execute()
+
+                    p0.assert_called_once()
+                    p1.assert_called_once()
+                    p2.assert_called_once()
+
+    def test_03_upsert_missing_upsert_cols(self):
+        test_df = Spark.get().createDataFrame(
+            [], schema="id string, EnqueuedTimestamp timestamp"
+        )
+        dh_source_mock = Mock()
+        dh_source_mock.read = Mock(return_value=test_df)
+        dh_target_mock = Mock()
+        dh_target_mock.read = Mock(return_value=test_df)
+
+        with patch.object(IncrementalExtractor, "read", return_value=test_df) as p0:
+            with patch.object(
+                EhJsonToDeltaTransformer, "process", return_value=test_df
+            ) as p1:
+                with patch.object(UpsertLoader, "save", return_value=test_df) as p2:
+                    with self.assertRaises(MissingUpsertJoinColumns) as cm:
+                        orchestrator = EhToDeltaSilverOrchestrator(
+                            dh_source=dh_source_mock,
+                            dh_target=dh_target_mock,
+                            mode="upsert",
+                        )
+                        orchestrator.execute()
+
+                        p0.assert_called_once()
+                        p1.assert_called_once()
+                        p2.assert_called_once()
+                        cm.exception = "You must specify upsert_join_cols"
+
+    def test_04_w_transformer(self):
         test_df = Spark.get().createDataFrame(
             [], schema="id string, EnqueuedTimestamp timestamp"
         )
@@ -75,7 +129,32 @@ class EhToDeltaSilverOrchestratorTests(DataframeTestCase):
                 dh_target_mock.upsert.assert_called_once()
                 p3.assert_called_once()
 
-    def test_03_append(self):
+    def test_05_append(self):
+        test_df = Spark.get().createDataFrame(
+            [], schema="id string, EnqueuedTimestamp timestamp"
+        )
+        dh_source_mock = Mock()
+        dh_source_mock.read = Mock(return_value=test_df)
+        dh_target_mock = Mock()
+        dh_target_mock.read = Mock(return_value=test_df)
+
+        with patch.object(IncrementalExtractor, "read", return_value=test_df) as p0:
+            with patch.object(
+                EhJsonToDeltaTransformer, "process", return_value=test_df
+            ) as p1:
+                with patch.object(SimpleLoader, "save", return_value=test_df) as p2:
+                    orchestrator = EhToDeltaSilverOrchestrator(
+                        dh_source=dh_source_mock,
+                        dh_target=dh_target_mock,
+                        mode="append",
+                    )
+                    orchestrator.execute()
+
+                    p0.assert_called_once()
+                    p1.assert_called_once()
+                    p2.assert_called_once()
+
+    def test_06_overwrite(self):
         test_df = Spark.get().createDataFrame(
             [], schema="id string, EnqueuedTimestamp timestamp"
         )
@@ -92,7 +171,7 @@ class EhToDeltaSilverOrchestratorTests(DataframeTestCase):
                     orchestrator = EhToDeltaSilverOrchestrator(
                         dh_source=dh_source_mock,
                         dh_target=dh_target_mock,
-                        mode="append",
+                        mode="overwrite",
                     )
                     orchestrator.execute()
 


### PR DESCRIPTION
When appending data to silver - it makes sense to use incremental extraction.

Now, when using "append" - all data is appended each time the orchestrator is runned. 